### PR TITLE
Damage outside area tests

### DIFF
--- a/native/lambda_game_engine/src/effect.rs
+++ b/native/lambda_game_engine/src/effect.rs
@@ -8,6 +8,7 @@ pub struct Effect {
     pub effect_time_type: TimeType,
     pub player_attributes: Vec<AttributeChange>,
     pub projectile_attributes: Vec<AttributeChange>,
+    pub skills_to_execute: Vec<String>,
 }
 
 #[derive(Deserialize, NifMap, Clone)]

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -178,13 +178,6 @@ impl GameState {
             if let Some(skill) = player.character.clone().skills.get(skill_key) {
                 player.add_action(Action::UsingSkill(skill_key.to_string()), skill.execution_duration_ms);
 
-                // let direction_angle = skill_params
-                //     .get("direction_angle")
-                //     .map(|angle_str| angle_str.parse::<f32>().unwrap())
-                //     .unwrap();
-
-                // player.direction = direction_angle;
-
                 for mechanic in skill.mechanics.iter() {
                     match mechanic {
                         SkillMechanic::SimpleShoot {
@@ -200,72 +193,6 @@ impl GameState {
                                 projectile_config,
                             );
                             self.projectiles.push(projectile);
-                        }
-                        SkillMechanic::MultiShoot {
-                            projectile: projectile_config,
-                            count,
-                            cone_angle,
-                        } => {
-                            let direction_distribution =
-                                distribute_angle(player.direction, cone_angle, count);
-                            for direction in direction_distribution {
-                                let id = get_next_id(&mut self.next_id);
-                                let projectile = Projectile::new(
-                                    id,
-                                    player.position.clone(),
-                                    direction,
-                                    player.id,
-                                    projectile_config,
-                                );
-                                self.projectiles.push(projectile);
-                            }
-                        }
-                        SkillMechanic::GiveEffect{effects_to_give} => {
-                            for effect in effects_to_give.iter() {
-                                player.apply_effect(effect, EntityOwner::Player(player.id));
-                            }
-                        }
-                        SkillMechanic::Hit {
-                            damage,
-                            range,
-                            cone_angle,
-                            on_hit_effects,
-                        } => {
-                            let mut damage = *damage;
-
-                            for (effect, _owner) in player.effects.iter() {
-                                for change in effect.player_attributes.iter() {
-                                    if change.attribute == "damage" {
-                                        effect::modify_attribute(&mut damage, change)
-                                    }
-                                }
-                            }
-
-                            // other_players
-                            //     .iter_mut()
-                            //     .filter(|target_player| {
-                            //         map::in_cone_angle_range(
-                            //             player,
-                            //             target_player,
-                            //             *range,
-                            //             *cone_angle as f32,
-                            //         )
-                            //     })
-                            //     .for_each(|target_player| {
-                            //         target_player.decrease_health(damage);
-
-                            //         if target_player.status == PlayerStatus::Death {
-                            //             self.next_killfeed.push(KillEvent {
-                            //                 kill_by: EntityOwner::Player(player.id),
-                            //                 killed: target_player.id,
-                            //             })
-                            //         } else {
-                            //             target_player.apply_effects(
-                            //                 on_hit_effects,
-                            //                 EntityOwner::Player(player.id),
-                            //             );
-                            //         }
-                            //     })
                         }
                         _ => todo!("SkillMechanic not implemented"),
                     }

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -173,32 +173,35 @@ impl GameState {
 
     fn activate_skills(&mut self) {
         self.players.values_mut().for_each(|player| {
-        let skills = player.skills_to_execute.clone();
-        skills.iter().for_each(|skill_key: &String| {
-            if let Some(skill) = player.character.clone().skills.get(skill_key) {
-                player.add_action(Action::UsingSkill(skill_key.to_string()), skill.execution_duration_ms);
+            let skills = player.skills_to_execute.clone();
+            skills.iter().for_each(|skill_key: &String| {
+                if let Some(skill) = player.character.clone().skills.get(skill_key) {
+                    player.add_action(
+                        Action::UsingSkill(skill_key.to_string()),
+                        skill.execution_duration_ms,
+                    );
 
-                for mechanic in skill.mechanics.iter() {
-                    match mechanic {
-                        SkillMechanic::SimpleShoot {
-                            projectile: projectile_config,
-                        } => {
-                            let id = get_next_id(&mut self.next_id);
+                    for mechanic in skill.mechanics.iter() {
+                        match mechanic {
+                            SkillMechanic::SimpleShoot {
+                                projectile: projectile_config,
+                            } => {
+                                let id = get_next_id(&mut self.next_id);
 
-                            let projectile = Projectile::new(
-                                id,
-                                player.position.clone(),
-                                player.direction,
-                                player.id,
-                                projectile_config,
-                            );
-                            self.projectiles.push(projectile);
+                                let projectile = Projectile::new(
+                                    id,
+                                    player.position.clone(),
+                                    player.direction,
+                                    player.id,
+                                    projectile_config,
+                                );
+                                self.projectiles.push(projectile);
+                            }
+                            _ => todo!("SkillMechanic not implemented"),
                         }
-                        _ => todo!("SkillMechanic not implemented"),
                     }
                 }
-            }
-        })
+            })
         });
     }
 
@@ -264,7 +267,7 @@ impl GameState {
                                 self.projectiles.push(projectile);
                             }
                         }
-                        SkillMechanic::GiveEffect{effects_to_give} => {
+                        SkillMechanic::GiveEffect { effects_to_give } => {
                             for effect in effects_to_give.iter() {
                                 player.apply_effect(effect, EntityOwner::Player(player.id));
                             }

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -220,6 +220,53 @@ impl GameState {
                                 self.projectiles.push(projectile);
                             }
                         }
+                        SkillMechanic::GiveEffect{effects_to_give} => {
+                            for effect in effects_to_give.iter() {
+                                player.apply_effect(effect, EntityOwner::Player(player.id));
+                            }
+                        }
+                        SkillMechanic::Hit {
+                            damage,
+                            range,
+                            cone_angle,
+                            on_hit_effects,
+                        } => {
+                            let mut damage = *damage;
+
+                            for (effect, _owner) in player.effects.iter() {
+                                for change in effect.player_attributes.iter() {
+                                    if change.attribute == "damage" {
+                                        effect::modify_attribute(&mut damage, change)
+                                    }
+                                }
+                            }
+
+                            // other_players
+                            //     .iter_mut()
+                            //     .filter(|target_player| {
+                            //         map::in_cone_angle_range(
+                            //             player,
+                            //             target_player,
+                            //             *range,
+                            //             *cone_angle as f32,
+                            //         )
+                            //     })
+                            //     .for_each(|target_player| {
+                            //         target_player.decrease_health(damage);
+
+                            //         if target_player.status == PlayerStatus::Death {
+                            //             self.next_killfeed.push(KillEvent {
+                            //                 kill_by: EntityOwner::Player(player.id),
+                            //                 killed: target_player.id,
+                            //             })
+                            //         } else {
+                            //             target_player.apply_effects(
+                            //                 on_hit_effects,
+                            //                 EntityOwner::Player(player.id),
+                            //             );
+                            //         }
+                            //     })
+                        }
                         _ => todo!("SkillMechanic not implemented"),
                     }
                 }
@@ -290,8 +337,8 @@ impl GameState {
                                 self.projectiles.push(projectile);
                             }
                         }
-                        SkillMechanic::GiveEffect(effects) => {
-                            for effect in effects.iter() {
+                        SkillMechanic::GiveEffect{effects_to_give} => {
+                            for effect in effects_to_give.iter() {
                                 player.apply_effect(effect, EntityOwner::Player(player.id));
                             }
                         }

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -28,6 +28,7 @@ pub struct Player {
     pub size: u64,
     pub speed: u64,
     pub action_duration_ms: u64,
+    pub skills_to_execute: Vec<String>,
     next_actions: Vec<Action>,
 }
 
@@ -65,6 +66,7 @@ impl Player {
             character: character_config,
             action_duration_ms: 0,
             next_actions: Vec::new(),
+            skills_to_execute: Vec::new(),
         }
     }
 
@@ -235,6 +237,8 @@ impl Player {
     }
 
     pub fn run_effects(&mut self, time_diff: u64) -> Option<EntityOwner> {
+        let mut skills_to_execute: Vec<String> = Vec::new();
+
         for (effect, owner) in self.effects.iter_mut() {
             match &mut effect.effect_time_type {
                 TimeType::Duration { duration_ms } => {
@@ -251,6 +255,10 @@ impl Player {
                     if *time_since_last_trigger >= *interval_ms {
                         *time_since_last_trigger -= *interval_ms;
                         *trigger_count -= 1;
+
+                        effect.skills_to_execute.iter().for_each(|skill| {
+                            skills_to_execute.push(skill.to_string())
+                        });
 
                         effect.player_attributes.iter().for_each(|change| {
                             match change.attribute.as_str() {
@@ -277,7 +285,7 @@ impl Player {
                 _ => todo!(),
             }
         }
-
+        self.skills_to_execute = skills_to_execute;
         None
     }
 }

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -256,9 +256,10 @@ impl Player {
                         *time_since_last_trigger -= *interval_ms;
                         *trigger_count -= 1;
 
-                        effect.skills_to_execute.iter().for_each(|skill| {
-                            skills_to_execute.push(skill.to_string())
-                        });
+                        effect
+                            .skills_to_execute
+                            .iter()
+                            .for_each(|skill| skills_to_execute.push(skill.to_string()));
 
                         effect.player_attributes.iter().for_each(|change| {
                             match change.attribute.as_str() {

--- a/native/lambda_game_engine/src/skill.rs
+++ b/native/lambda_game_engine/src/skill.rs
@@ -23,7 +23,9 @@ pub struct SkillConfig {
 
 #[derive(Deserialize)]
 pub enum SkillMechanicConfigFile {
-    GiveEffect(Vec<String>),
+    GiveEffect {
+        effects_to_give: Vec<String>,
+    },
     Hit {
         damage: u64,
         range: u64,
@@ -46,7 +48,9 @@ pub enum SkillMechanicConfigFile {
 
 #[derive(NifTaggedEnum, Clone)]
 pub enum SkillMechanic {
-    GiveEffect(Vec<Effect>),
+    GiveEffect {
+        effects_to_give: Vec<Effect>,
+    },
     Hit {
         damage: u64,
         range: u64,
@@ -100,13 +104,13 @@ impl SkillMechanic {
         mechanics
             .into_iter()
             .map(|config| match config {
-                SkillMechanicConfigFile::GiveEffect(config_effects) => {
+                SkillMechanicConfigFile::GiveEffect{effects_to_give} => {
                     let effects = effects
                         .iter()
-                        .filter(|effect| config_effects.contains(&effect.name))
+                        .filter(|effect| effects_to_give.contains(&effect.name))
                         .cloned()
                         .collect();
-                    SkillMechanic::GiveEffect(effects)
+                    SkillMechanic::GiveEffect{effects_to_give: effects}
                 }
                 SkillMechanicConfigFile::Hit {
                     damage,

--- a/native/lambda_game_engine/src/skill.rs
+++ b/native/lambda_game_engine/src/skill.rs
@@ -104,13 +104,15 @@ impl SkillMechanic {
         mechanics
             .into_iter()
             .map(|config| match config {
-                SkillMechanicConfigFile::GiveEffect{effects_to_give} => {
+                SkillMechanicConfigFile::GiveEffect { effects_to_give } => {
                     let effects = effects
                         .iter()
                         .filter(|effect| effects_to_give.contains(&effect.name))
                         .cloned()
                         .collect();
-                    SkillMechanic::GiveEffect{effects_to_give: effects}
+                    SkillMechanic::GiveEffect {
+                        effects_to_give: effects,
+                    }
                 }
                 SkillMechanicConfigFile::Hit {
                     damage,

--- a/priv/test_config.json
+++ b/priv/test_config.json
@@ -143,6 +143,19 @@
       ]
     },
     {
+      "name": "slingshot_burst",
+      "cooldown_ms": 800,
+      "execution_duration_ms": 250,
+      "is_passive": false,
+      "mechanics": [
+        {
+          "GiveEffect": {
+            "effects_to_give": ["auto_slingshot"]
+          }
+        }
+      ]
+    },
+    {
       "name": "single_slingshot",
       "cooldown_ms": 800,
       "execution_duration_ms": 250,
@@ -209,7 +222,7 @@
       "base_size": 80,
       "base_health": 100,
       "skills": {
-        "1": "slingshot",
+        "1": "slingshot_burst",
         "2": "single_slingshot",
         "3": "poison_dart"
       }

--- a/priv/test_config.json
+++ b/priv/test_config.json
@@ -143,32 +143,6 @@
       ]
     },
     {
-      "name": "slingshot_burst",
-      "cooldown_ms": 800,
-      "execution_duration_ms": 250,
-      "is_passive": false,
-      "mechanics": [
-        {
-          "GiveEffect": {
-            "effects_to_give": ["auto_slingshot"]
-          }
-        }
-      ]
-    },
-    {
-      "name": "single_slingshot",
-      "cooldown_ms": 800,
-      "execution_duration_ms": 250,
-      "is_passive": false,
-      "mechanics": [
-        {
-          "SimpleShoot": {
-            "projectile": "projectile_slingshot"
-          }
-        }
-      ]
-    },
-    {
       "name": "poison_dart",
       "cooldown_ms": 800,
       "execution_duration_ms": 150,
@@ -222,8 +196,7 @@
       "base_size": 80,
       "base_health": 100,
       "skills": {
-        "1": "slingshot_burst",
-        "2": "single_slingshot",
+        "1": "slingshot",
         "3": "poison_dart"
       }
     },

--- a/priv/test_config.json
+++ b/priv/test_config.json
@@ -15,7 +15,8 @@
           "value": "1.2"
         }
       ],
-      "projectile_attributes": []
+      "projectile_attributes": [],
+      "skills_to_execute": []
     },
     {
       "name": "heal_30",
@@ -28,7 +29,8 @@
           "value": "30"
         }
       ],
-      "projectile_attributes": []
+      "projectile_attributes": [],
+      "skills_to_execute": []
     },
     {
       "name": "h4ck_dos",
@@ -56,7 +58,8 @@
           "modifier": "Override",
           "value": "false"
         }
-      ]
+      ],
+      "skills_to_execute": []
     },
     {
       "name": "damage_outside_area",
@@ -75,7 +78,8 @@
           "value": "-10"
         }
       ],
-      "projectile_attributes": []
+      "projectile_attributes": [],
+      "skills_to_execute": []
     },
     {
       "name": "poison",
@@ -94,7 +98,8 @@
           "value": "0.95"
         }
       ],
-      "projectile_attributes": []
+      "projectile_attributes": [],
+      "skills_to_execute": []
     }
   ],
   "loots": [

--- a/priv/test_config.json
+++ b/priv/test_config.json
@@ -143,6 +143,19 @@
       ]
     },
     {
+      "name": "single_slingshot",
+      "cooldown_ms": 800,
+      "execution_duration_ms": 250,
+      "is_passive": false,
+      "mechanics": [
+        {
+          "SimpleShoot": {
+            "projectile": "projectile_slingshot"
+          }
+        }
+      ]
+    },
+    {
       "name": "poison_dart",
       "cooldown_ms": 800,
       "execution_duration_ms": 150,
@@ -197,6 +210,7 @@
       "base_health": 100,
       "skills": {
         "1": "slingshot",
+        "2": "single_slingshot",
         "3": "poison_dart"
       }
     },


### PR DESCRIPTION
GiveEffect mechanic skill behavior was not implemented and it's a good way to implement the h4ck ultimate skill.
This PR adds a new parameter so an effect can trigger a skill as its effect.

## Changes

- [Add new parameter skills_to_execute to store all the skills that should be executed due to an effect](https://github.com/lambdaclass/game_backend/pull/41/commits/4bb43a7c6baa96240aa5f2bedd4a6ee5637c2ff5)
- [Add new activate_skills function to consume all skills that need to be executed due to an effect](https://github.com/lambdaclass/game_backend/pull/41/commits/968d9efa4bbe3d2be81a67733b1d90b4fd602fec)
- [Add new skill mechanic GiveEffect behavior](https://github.com/lambdaclass/game_backend/pull/41/commits/b1482b0c6a500445e576b80c7c6e4e2e57c1a606)

## How to test it?

- To test this PR you have to use the server (elixir) branch: gh-794-add-h4ck-ultimate-skill and use the h4ck 1st skill.
