### PR TITLE
Count players on matchmaking scene

### DIFF
--- a/lib/dark_worlds_server/communication.ex
+++ b/lib/dark_worlds_server/communication.ex
@@ -46,6 +46,15 @@ defmodule DarkWorldsServer.Communication do
     |> LobbyEvent.encode()
   end
 
+  def notify_player_amount!(amount_of_players, capacity) do
+    %LobbyEvent{
+      type: :NOTIFY_PLAYER_AMOUNT,
+      amount_of_players: amount_of_players,
+      capacity: capacity
+    }
+    |> LobbyEvent.encode()
+  end
+
   def game_update!(%{
         players: players,
         projectiles: projectiles,

--- a/lib/dark_worlds_server/communication/messages.pb.ex
+++ b/lib/dark_worlds_server/communication/messages.pb.ex
@@ -107,6 +107,7 @@ defmodule DarkWorldsServer.Communication.Proto.LobbyEventType do
   field(:PLAYER_ADDED, 2)
   field(:GAME_STARTED, 3)
   field(:START_GAME, 4)
+  field(:NOTIFY_PLAYER_AMOUNT, 5)
 end
 
 defmodule DarkWorldsServer.Communication.Proto.ProjectileType do
@@ -402,6 +403,8 @@ defmodule DarkWorldsServer.Communication.Proto.LobbyEvent do
 
   field(:server_hash, 10, type: :string, json_name: "serverHash")
   field(:host_player_id, 11, type: :uint64, json_name: "hostPlayerId")
+  field(:amount_of_players, 12, type: :uint64, json_name: "amountOfPlayers")
+  field(:capacity, 13, type: :uint64)
 
   def transform_module(), do: DarkWorldsServer.Communication.ProtoTransform
 end

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -105,7 +105,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   end
 
   defp notify_players_amount(players, capacity) do
-    amount = Enum.count(players)
+amount = length(players)
 
     players
     |> Enum.each(fn {_, client_pid} ->

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -41,9 +41,9 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   end
 
   def handle_call({:join, user_id}, {from, _}, state) do
-      players = state.players ++ [{user_id, from}]
-      send(self(), :check_capacity)
-      {:reply, :ok, %{state | players: players}}
+    players = state.players ++ [{user_id, from}]
+    send(self(), :check_capacity)
+    {:reply, :ok, %{state | players: players}}
   end
 
   def handle_call({:leave, user_id}, _from, state) do

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -104,9 +104,11 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   end
 
   defp notify_players_amount(players, capacity) do
+    amount = Enum.count(players)
+
     players
     |> Enum.each(fn {_, client_pid} ->
-      Process.send(client_pid, {:notify_players_amount, Enum.count(players), capacity}, [])
+      Process.send(client_pid, {:notify_players_amount, amount, capacity}, [])
     end)
   end
 end

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -100,7 +100,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
 
   defp consume_and_notify_players([{_, client_pid} | rest_players], game_pid, game_config, count) do
     Process.send_after(client_pid, {:game_started, game_pid, game_config}, 500)
-    Process.send(client_pid, {:notify_players_amount, 10, 10}, [])
+    Process.send(client_pid, {:notify_players_amount, @session_player_amount, @session_player_amount}, [])
     consume_and_notify_players(rest_players, game_pid, game_config, count - 1)
   end
 

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -105,7 +105,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   end
 
   defp notify_players_amount(players, capacity) do
-amount = length(players)
+    amount = length(players)
 
     players
     |> Enum.each(fn {_, client_pid} ->

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -68,7 +68,6 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
 
   def handle_info(:check_capacity, %{players: players} = state) when length(players) >= @session_player_amount do
     {:ok, game_pid, game_config} = start_game()
-    notify_players_amount(@session_player_amount, @session_player_amount)
     players = consume_and_notify_players(state.players, game_pid, game_config, @session_player_amount)
     new_session_ref = make_ref()
     Process.send_after(self(), {:check_timeout, new_session_ref}, @start_game_timeout_ms)

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -5,7 +5,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   ## Amount of players needed to start a game
   @session_player_amount 10
   ## Time to wait for a matching session to be full
-  @start_game_timeout_ms 10_000
+  @start_game_timeout_ms 9_500
 
   #######
   # API #
@@ -99,7 +99,8 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   end
 
   defp consume_and_notify_players([{_, client_pid} | rest_players], game_pid, game_config, count) do
-    Process.send_after(client_pid, {:game_started, game_pid, game_config}, 1_000)
+    Process.send_after(client_pid, {:game_started, game_pid, game_config}, 500)
+    Process.send(client_pid, {:notify_players_amount, 10, 10}, [])
     consume_and_notify_players(rest_players, game_pid, game_config, count - 1)
   end
 

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -109,6 +109,8 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
 
   defp notify_players_amount(players, capacity) do
     players
-    |> Enum.each(fn {_, client_pid} -> Process.send(client_pid, {:notify_players_amount, Enum.count(players), capacity}, []) end)
+    |> Enum.each(fn {_, client_pid} ->
+      Process.send(client_pid, {:notify_players_amount, Enum.count(players), capacity}, [])
+    end)
   end
 end

--- a/lib/dark_worlds_server_web/websockets/lobby_websocket.ex
+++ b/lib/dark_worlds_server_web/websockets/lobby_websocket.ex
@@ -30,6 +30,10 @@ defmodule DarkWorldsServerWeb.LobbyWebsocket do
     {:reply, {:binary, Communication.lobby_player_added!(player_id, player_name, host_player_id, players)}, state}
   end
 
+  def websocket_info({:notify_players_amount, amount_of_players, capacity}, state) do
+    {:reply, {:binary, Communication.notify_player_amount!(amount_of_players, capacity)}, state}
+  end
+
   def websocket_info({:game_started, game_pid, game_config}, state) do
     new_state = Map.put(state, :game_started, true)
     server_hash = Application.get_env(:dark_worlds_server, :information) |> Keyword.get(:version_hash)

--- a/load_test/lib/load_test/communication/messages.pb.ex
+++ b/load_test/lib/load_test/communication/messages.pb.ex
@@ -107,6 +107,7 @@ defmodule LoadTest.Communication.Proto.LobbyEventType do
   field(:PLAYER_ADDED, 2)
   field(:GAME_STARTED, 3)
   field(:START_GAME, 4)
+  field(:NOTIFY_PLAYER_AMOUNT, 5)
 end
 
 defmodule LoadTest.Communication.Proto.ProjectileType do
@@ -153,6 +154,7 @@ defmodule LoadTest.Communication.Proto.MechanicType do
   field(:HIT, 0)
   field(:SIMPLE_SHOOT, 1)
   field(:MULTI_SHOOT, 2)
+  field(:GIVE_EFFECT, 3)
 end
 
 defmodule LoadTest.Communication.Proto.GameEvent.SelectedCharactersEntry do
@@ -224,7 +226,7 @@ defmodule LoadTest.Communication.Proto.Player do
   field(:health, 2, type: :sint64)
   field(:position, 3, type: LoadTest.Communication.Proto.Position)
   field(:status, 4, type: LoadTest.Communication.Proto.Status, enum: true)
-  field(:action, 5, type: LoadTest.Communication.Proto.PlayerAction, enum: true)
+  field(:action, 5, repeated: true, type: LoadTest.Communication.Proto.PlayerAction, enum: true)
   field(:aoe_position, 6, type: LoadTest.Communication.Proto.Position, json_name: "aoePosition")
   field(:kill_count, 7, type: :uint64, json_name: "killCount")
   field(:death_count, 8, type: :uint64, json_name: "deathCount")
@@ -264,6 +266,7 @@ defmodule LoadTest.Communication.Proto.Player do
 
   field(:direction, 16, type: LoadTest.Communication.Proto.RelativePosition)
   field(:body_size, 17, type: :float, json_name: "bodySize")
+  field(:action_duration_ms, 18, type: :uint64, json_name: "actionDurationMs")
 end
 
 defmodule LoadTest.Communication.Proto.EffectInfo do
@@ -362,6 +365,8 @@ defmodule LoadTest.Communication.Proto.LobbyEvent do
   field(:game_config, 9, type: LoadTest.Communication.Proto.Config, json_name: "gameConfig")
   field(:server_hash, 10, type: :string, json_name: "serverHash")
   field(:host_player_id, 11, type: :uint64, json_name: "hostPlayerId")
+  field(:amount_of_players, 12, type: :uint64, json_name: "amountOfPlayers")
+  field(:capacity, 13, type: :uint64)
 end
 
 defmodule LoadTest.Communication.Proto.PlayerInformation do

--- a/messages.proto
+++ b/messages.proto
@@ -236,6 +236,8 @@ message LobbyEvent {
     Config game_config = 9;
     string server_hash = 10;
     uint64 host_player_id = 11;
+    uint64 amount_of_players = 12;
+    uint64 capacity = 13;
 }
 
 /* Represents the information of a player/client
@@ -333,6 +335,7 @@ enum LobbyEventType {
     PLAYER_ADDED = 2;
     GAME_STARTED = 3;
     START_GAME = 4;
+    NOTIFY_PLAYER_AMOUNT = 5;
 }
 
 


### PR DESCRIPTION
Added a new lobby event trigger for every time a player joins or leaves a lobby to be displayed on the scene

We'll send a dummy number just before the match start to tell the user that there're 10 players in the lobby

This pr should be tested an merged alongside this [PR](https://github.com/lambdaclass/curse_of_myrra/pull/1228) from the curse of myrra repo