### PR TITLE
Avoid creating new players in queue if already present

### DIFF
--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -40,7 +40,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
     {:reply, :ok, %{state | players: players, session: session_ref}}
   end
 
-  def handle_call({:join, user_id}, {from, _}, %{players: players} =state) do
+  def handle_call({:join, user_id}, {from, _}, %{players: players} = state) do
     if Enum.any?(players, fn {player_user_id, _} -> player_user_id == user_id end) do
       send(self(), :check_capacity)
       {:reply, :ok, state}

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -45,7 +45,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
     if Enum.any?(players, fn {player_user_id, _} -> player_user_id == user_id end) do
       {:reply, :ok, state}
     else
-      players = state.players ++ [{user_id, from}]
+      players = [{user_id, from} | state.players]
       send(self(), :check_capacity)
       {:reply, :ok, %{state | players: players}}
     end

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -42,7 +42,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
 
   def handle_call({:join, user_id}, {from, _}, %{players: players} = state) do
     if Enum.any?(players, fn {player_user_id, _} -> player_user_id == user_id end) do
-      send(self(), :check_capacity)
+      notify_players_amount(players, @session_player_amount)
       {:reply, :ok, state}
     else
       players = state.players ++ [{user_id, from}]

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -40,10 +40,15 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
     {:reply, :ok, %{state | players: players, session: session_ref}}
   end
 
-  def handle_call({:join, user_id}, {from, _}, state) do
-    players = state.players ++ [{user_id, from}]
-    send(self(), :check_capacity)
-    {:reply, :ok, %{state | players: players}}
+  def handle_call({:join, user_id}, {from, _}, %{players: players} =state) do
+    if Enum.any?(players, fn {player_user_id, _} -> player_user_id == user_id end) do
+      send(self(), :check_capacity)
+      {:reply, :ok, state}
+    else
+      players = state.players ++ [{user_id, from}]
+      send(self(), :check_capacity)
+      {:reply, :ok, %{state | players: players}}
+    end
   end
 
   def handle_call({:leave, user_id}, _from, state) do

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -42,7 +42,6 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
 
   def handle_call({:join, user_id}, {from, _}, %{players: players} = state) do
     if Enum.any?(players, fn {player_user_id, _} -> player_user_id == user_id end) do
-      notify_players_amount(players, @session_player_amount)
       {:reply, :ok, state}
     else
       players = state.players ++ [{user_id, from}]


### PR DESCRIPTION
If you spammed the "Play" button from the client we were always adding a new player to the lobby count causing issues

We'll not add the players to the queue if they already exists in the players waiting for a lobby

This pr should be tested and merged with [this pr](https://github.com/lambdaclass/curse_of_myrra/pull/1238) from the client repo