### PR TITLE
Fix bot wandering in circular map

### DIFF
--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -150,7 +150,7 @@ impl GameState {
             loots: Vec::new(),
             projectiles: Vec::new(),
             zone: Zone {
-                center: map::random_position(game_width, game_height),
+                center: Position { x: 0, y: 0}, //map::random_position(game_width, game_height),
                 radius: zone_radius,
                 modifications: zone_modifications,
                 current_modification: None,

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -141,8 +141,9 @@ impl GameState {
     pub fn new(config: Config) -> Self {
         let zone_radius = config.game.zone_starting_radius;
         let zone_modifications = config.game.zone_modifications.clone();
-        let game_width = config.game.width;
-        let game_height = config.game.height;
+        // The zone is disabled for now
+        // let game_width = config.game.width;
+        // let game_height = config.game.height;
 
         Self {
             config,

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -150,7 +150,7 @@ impl GameState {
             loots: Vec::new(),
             projectiles: Vec::new(),
             zone: Zone {
-                center: Position { x: 0, y: 0}, //map::random_position(game_width, game_height),
+                center: Position { x: 0, y: 0 }, //map::random_position(game_width, game_height),
                 radius: zone_radius,
                 modifications: zone_modifications,
                 current_modification: None,

--- a/priv/config.json
+++ b/priv/config.json
@@ -269,7 +269,7 @@
   "game": {
     "width": 10000,
     "height": 10000,
-    "zone_starting_radius": 14000,
+    "zone_starting_radius": 5000,
     "zone_modifications": [
       {
         "duration_ms": 999999,
@@ -279,7 +279,7 @@
         },
         "interval_ms": 500,
         "min_radius": 5000,
-        "max_radius": 10000,
+        "max_radius": 5000,
         "outside_radius_effects": []
       },
       {


### PR DESCRIPTION
Currently bots have a state where they move towards a location. That location might be outside of the map. Since they use the zone as a means to decide the next location and it's currently disabled, we'll change the zone bounds to make sure the bots move within the map.

You can test this with main branch on the client