### PR TITLE
Add random modifier to bot behavior

### DIFF
--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -475,12 +475,6 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
     end
   end
 
-  def random_chance(chance \\ 100, additive)
-
-  def random_chance(chance, additive) do
-    :rand.uniform(chance) <= @random_factor + additive
-  end
-
   defp maybe_add_inaccuracy_to_angle(angle, false), do: angle
 
   defp maybe_add_inaccuracy_to_angle(angle, true) do

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -91,7 +91,7 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
           bot_state
 
         bot_state ->
-          Process.send_after(self(), {:decide_action, bot_id}, @decide_delay_ms + (@random_factor * 2))
+          Process.send_after(self(), {:decide_action, bot_id}, @decide_delay_ms + @random_factor * 2)
 
           bot = Enum.find(state.players, fn player -> player.id == bot_id end)
 

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -481,13 +481,6 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
     :rand.uniform(chance) <= @random_factor + additive
   end
 
-  # We'll add a randomness to a position decided by the @random_factor variable so the bot behavior isn't 100% acurate
-  def add_randomness_to_position(%{x: x, y: y}) do
-    random_x = x + Enum.random(0..@random_factor) / 100 * Enum.random([-1, 1])
-    random_y = y + Enum.random(0..@random_factor) / 100 * Enum.random([-1, 1])
-    {random_x, random_y}
-  end
-
   defp maybe_add_inaccuracy_to_angle(angle, false), do: angle
 
   defp maybe_add_inaccuracy_to_angle(angle, true) do

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -12,7 +12,7 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
   @random_factor Enum.random([10, 30, 60, 80])
 
   # This variable will decide how much time passes between bot decisions in milis
-  @decide_delay_ms 500 + (@random_factor * 2)
+  @decide_delay_ms 500 + @random_factor * 2
 
   # We'll decide the view range of a bot measured in grid cells
   # e.g. from {x=1, y=1} to {x=5, y=1} you have 4 cells

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -2,8 +2,17 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
   use GenServer, restart: :transient
   require Logger
 
+  # The random factor will add a layer of randomness to bot actions
+  # The following actions will be afected:
+  # - Bot decision, the bot will start a wandering cicle with an fourth times
+  #   chance and an eight times chance to do nothing
+  # - Every attack the bot do will have a tilt that's decided with the random factor
+  # - Add an additive to the range of attacks they're not always accurate
+  # - Add some miliseconds to the time of decision of the bot
+  @random_factor Enum.random([10, 30, 60, 80])
+
   # This variable will decide how much time passes between bot decisions in milis
-  @decide_delay_ms 500
+  @decide_delay_ms 500 + (@random_factor * 2)
 
   # We'll decide the view range of a bot measured in grid cells
   # e.g. from {x=1, y=1} to {x=5, y=1} you have 4 cells
@@ -23,15 +32,6 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
 
   # This is the amount of time between bots messages
   @game_tick_rate_ms 30
-
-  # The random factor will add a layer of randomness to bot actions
-  # The following actions will be afected:
-  # - Bot decision, the bot will start a wandering cicle with an fourth times
-  #   chance and an eight times chance to do nothing
-  # - Every attack the bot do will have a tilt that's decided with the random factor
-  # - Add an additive to the range of attacks they're not always accurate
-  # - Add some miliseconds to the time of decision of the bot
-  @random_factor Enum.random([10, 30, 60, 80])
 
   #######
   # API #
@@ -92,7 +92,7 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
           bot_state
 
         bot_state ->
-          Process.send_after(self(), {:decide_action, bot_id}, @decide_delay_ms + @random_factor * 2)
+          Process.send_after(self(), {:decide_action, bot_id}, @decide_delay_ms)
 
           bot = Enum.find(state.players, fn player -> player.id == bot_id end)
 

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -26,7 +26,8 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
 
   # The random factor will add a layer of randomness to bot actions
   # The following actions will be afected:
-  # - Bot decision, the bot will start a wandering cicle with an fourth times chance and an eight times chance to do nothing
+  # - Bot decision, the bot will start a wandering cicle with an fourth times
+  #   chance and an eight times chance to do nothing
   # - Every attack the bot do will have a tilt that's decided with the random factor
   # - Add an additive to the range of attacks they're not always accurate
   # - Add some miliseconds to the time of decision of the bot


### PR DESCRIPTION
Now the bot_player will have a random number called "random_factor" this number will be used to determine certain modifiers on the bot behvaior.

The affected actions are:
- Added a little delay in the decision interval to simulate an user delay
- Fixed angle tilt in the attack
- The bot has a chance in four of the random_factor value to change his decision to wander
- The bot has a chance in eight of the random_factor value to change to nothing for a cicle