### PR TITLE
simulate player joining on lobby

### DIFF
--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -28,7 +28,8 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   #######################
   @impl true
   def init(_args) do
-    {:ok, %{players: [], session: :unset}}
+    send(self(), :simulate_player_joined)
+    {:ok, %{players: [], session: :unset, curent_lobby_players: 0}}
   end
 
   @impl true
@@ -36,9 +37,10 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
     session_ref = make_ref()
     Process.send_after(self(), {:check_timeout, session_ref}, @start_game_timeout_ms)
     players = [{user_id, from}]
-    notify_players_amount(players, @session_player_amount)
+    new_state = %{state | players: players, session: session_ref, curent_lobby_players: 1}
+    notify_players_amount(new_state, @session_player_amount)
 
-    {:reply, :ok, %{state | players: players, session: session_ref}}
+    {:reply, :ok, new_state}
   end
 
   def handle_call({:join, user_id}, {from, _}, %{players: players} = state) do
@@ -47,41 +49,62 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
     else
       players = [{user_id, from} | state.players]
       send(self(), :check_capacity)
-      {:reply, :ok, %{state | players: players}}
+      new_state = %{state | players: players, curent_lobby_players: state.curent_lobby_players + 1}
+      notify_players_amount(new_state, @session_player_amount)
+      {:reply, :ok, new_state}
     end
   end
 
   def handle_call({:leave, user_id}, _from, state) do
     players = Enum.filter(state.players, fn {player_user_id, _} -> player_user_id != user_id end)
-    notify_players_amount(players, @session_player_amount)
-    {:reply, :ok, %{state | players: players}}
+    new_state = %{state | players: players, curent_lobby_players: state.curent_lobby_players - 1}
+
+    notify_players_amount(new_state, @session_player_amount)
+    {:reply, :ok, new_state}
   end
 
   @impl true
   def handle_info({:check_timeout, session_ref}, %{session: session_ref, players: [_ | _]} = state) do
     bot_count = @session_player_amount - length(state.players)
     {:ok, game_pid, game_config} = start_game()
-    players = consume_and_notify_players(state.players, game_pid, game_config, @session_player_amount)
+    players = consume_and_notify_players(state.players, state, game_pid, game_config, @session_player_amount)
     trigger_bots(bot_count, game_pid)
     new_session_ref = make_ref()
     Process.send_after(self(), {:check_timeout, new_session_ref}, @start_game_timeout_ms)
-    {:noreply, %{state | players: players, session: new_session_ref}}
+    {:noreply, %{state | players: players, session: new_session_ref, curent_lobby_players: 0}}
   end
 
   def handle_info({:check_timeout, _session_ref}, %{session: _other_session_ref} = state) do
     {:noreply, state}
   end
 
-  def handle_info(:check_capacity, %{players: players} = state) when length(players) >= @session_player_amount do
-    {:ok, game_pid, game_config} = start_game()
-    players = consume_and_notify_players(state.players, game_pid, game_config, @session_player_amount)
-    new_session_ref = make_ref()
-    Process.send_after(self(), {:check_timeout, new_session_ref}, @start_game_timeout_ms)
-    {:noreply, %{state | players: players, session: new_session_ref}}
+  def handle_info(:simulate_player_joined, %{players: []} = state) do
+    Process.send_after(self(), :simulate_player_joined, 1000)
+    {:noreply, state}
   end
 
-  def handle_info(:check_capacity, %{players: players} = state) do
-    notify_players_amount(players, @session_player_amount)
+  def handle_info(:simulate_player_joined, %{curent_lobby_players: curent_lobby_players, players: players} = state) do
+    Process.send_after(self(), :simulate_player_joined, 1000)
+    current_player = length(players)
+    limit = @session_player_amount - (current_player + curent_lobby_players)
+
+    new_state =
+      %{state | curent_lobby_players: curent_lobby_players + Enum.random(0..Enum.min([2, limit]))}
+
+    notify_players_amount(new_state, @session_player_amount)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(:check_capacity, %{players: players} = state) when length(players) >= @session_player_amount do
+    {:ok, game_pid, game_config} = start_game()
+    players = consume_and_notify_players(state.players, state, game_pid, game_config, @session_player_amount)
+    new_session_ref = make_ref()
+    Process.send_after(self(), {:check_timeout, new_session_ref}, @start_game_timeout_ms)
+    {:noreply, %{state | players: players, session: new_session_ref, curent_lobby_players: 0}}
+  end
+
+  def handle_info(:check_capacity, state) do
     {:noreply, state}
   end
 
@@ -94,23 +117,21 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
     {:ok, game_pid, game_config}
   end
 
-  defp consume_and_notify_players(remaining_players, _, _, 0) do
+  defp consume_and_notify_players(remaining_players, _, _, _, 0) do
     remaining_players
   end
 
-  defp consume_and_notify_players([], _, _, _) do
+  defp consume_and_notify_players([], _, _, _, _) do
     []
   end
 
-  defp consume_and_notify_players([{_, client_pid} | rest_players], game_pid, game_config, count) do
+  defp consume_and_notify_players([{_, client_pid} | rest_players], state, game_pid, game_config, count) do
     Process.send(client_pid, {:preparing_game, game_pid, game_config}, [])
     Process.send(client_pid, {:notify_players_amount, @session_player_amount, @session_player_amount}, [])
-    consume_and_notify_players(rest_players, game_pid, game_config, count - 1)
+    consume_and_notify_players(rest_players, state, game_pid, game_config, count - 1)
   end
 
-  defp notify_players_amount(players, capacity) do
-    amount = length(players)
-
+  defp notify_players_amount(%{curent_lobby_players: amount, players: players}, capacity) do
     players
     |> Enum.each(fn {_, client_pid} ->
       Process.send(client_pid, {:notify_players_amount, amount, capacity}, [])

--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -83,10 +83,9 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
     {:noreply, state}
   end
 
-  def handle_info(:simulate_player_joined, %{curent_lobby_players: curent_lobby_players, players: players} = state) do
+  def handle_info(:simulate_player_joined, %{curent_lobby_players: curent_lobby_players} = state) do
     Process.send_after(self(), :simulate_player_joined, 1000)
-    current_player = length(players)
-    limit = @session_player_amount - (current_player + curent_lobby_players)
+    limit = @session_player_amount - curent_lobby_players
 
     new_state =
       %{state | curent_lobby_players: curent_lobby_players + Enum.random(0..Enum.min([2, limit]))}
@@ -132,6 +131,8 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   end
 
   defp notify_players_amount(%{curent_lobby_players: amount, players: players}, capacity) do
+    amount = Enum.max([length(players), amount])
+
     players
     |> Enum.each(fn {_, client_pid} ->
       Process.send(client_pid, {:notify_players_amount, amount, capacity}, [])


### PR DESCRIPTION
If you entered a lobby the player counter would remain in 1 and the jump instantly to 10, this is wrong and we should simulate player joining to the lobby while we wait