### PR TITLE
Increment muflus hit range and muflus base size

### DIFF
--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -364,7 +364,7 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
     # TODO: We should find a way to use the skill of the character distance
     case bot.character_name do
       "H4ck" -> distance_to_entity < 1000 and Enum.random(0..100) < 40
-      "Muflus" -> distance_to_entity < 450 and Enum.random(0..100) < 30
+      "Muflus" -> distance_to_entity < 975 and Enum.random(0..100) < 30
     end
   end
 

--- a/priv/config.json
+++ b/priv/config.json
@@ -208,7 +208,7 @@
         {
           "Hit": {
             "damage": 0,
-            "range": 675,
+            "range": 975,
             "cone_angle": 120,
             "on_hit_effects": ["muflus_hit_delay"]
           }
@@ -277,7 +277,7 @@
       "name": "muflus",
       "active": true,
       "base_speed": 25,
-      "base_size": 100,
+      "base_size": 150,
       "base_health": 100,
       "max_inventory_size": 1,
       "skills": {


### PR DESCRIPTION
Increment muflus hit range to 975 and muflus base size to 150 in order to improve the visualization of the attack effect together with the attack damage.