### PR TITLE
Fix muflus movement

### DIFF
--- a/native/game_backend/src/player.rs
+++ b/native/game_backend/src/player.rs
@@ -98,7 +98,8 @@ impl Player {
 
     pub fn update_actions(&mut self) {
         if !self.is_executing_action() {
-            self.next_actions.clear();
+            self.next_actions
+                .retain(|action| matches!(action, Action::Moving));
         }
         self.actions = self.next_actions.clone();
     }


### PR DESCRIPTION
Fix Muflus movement in order to execute all the movement orders, preventing a limp effect in the frontend