### PR TITLE
Name all dependencies and minor rust cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ format:
 
 check:
 	mix credo --strict
-	cargo clippy --manifest-path native/game_backend/Cargo.toml -- -D warnings
+	cargo clippy --manifest-path native/game_backend/Cargo.toml -- -D warnings -D clippy::nursery -D clippy::all -D clippy::complexity -A clippy::use_self 
 
 .PHONY: setup dependencies db stop start run tests elixir-tests shell prepush credo docs
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ be found at <https://hexdocs.pm/game_backend>.
 - Erlang OTP >= 26
 - Elixir >= 1.15.4
 - Docker and docker compose
-- inotify-utils (optional, for development live reload)
+- [inotify-utils](https://hexdocs.pm/phoenix/installation.html#inotify-tools-for-linux-users) if using Linux (optional, for development live reload)
 
 Ensure Docker is running and execute:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ be found at <https://hexdocs.pm/game_backend>.
 - Rust >= 1.72.0
 - Erlang OTP >= 26
 - Elixir >= 1.15.4
+- Docker and docker compose
+- inotify-utils (optional, for development live reload)
 
 Ensure Docker is running and execute:
 
@@ -63,4 +65,3 @@ make start
 ```
 
 ## Contributing
-

--- a/native/game_backend/Cargo.lock
+++ b/native/game_backend/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -171,9 +171,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustler"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884cb623b9f43d3e2c51f9071c5e96a5acf3e6e6007866812884ff0cb983f1e"
+checksum = "c4b4fea69e23de68c42c06769d6624d2d018da550c17244dd4b691f90ced4a7e"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -182,14 +182,14 @@ dependencies = [
 
 [[package]]
 name = "rustler_codegen"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e277af754f2560cf4c4ebedb68c1a735292fb354505c6133e47ec406e699cf"
+checksum = "406061bd07aaf052c344257afed4988c5ec8efe4d2352b4c2cf27ea7c8575b12"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn",
 ]
 
 [[package]]
@@ -247,32 +247,21 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]

--- a/native/game_backend/Cargo.toml
+++ b/native/game_backend/Cargo.toml
@@ -9,13 +9,17 @@ name = "game_backend"
 path = "src/lib.rs"
 crate-type = ["cdylib"]
 
+[profile.release]
+lto = true
+codegen-units = 1
+
 [dependencies]
-rustler = "0.29.1"
+rustler = "0.30.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # Dependencies for game_backend module
 # remove after removal of module
-itertools = "0.11.0"
+itertools = "0.12.0"
 rand = "0.8.5"
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.3"

--- a/native/game_backend/src/effect.rs
+++ b/native/game_backend/src/effect.rs
@@ -25,7 +25,7 @@ pub enum AttributeModifier {
     Override,
 }
 
-#[derive(Deserialize, NifTaggedEnum, Clone, PartialEq)]
+#[derive(Deserialize, NifTaggedEnum, Clone, PartialEq, Eq)]
 pub enum TimeType {
     Instant,
     Permanent,

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -592,9 +592,8 @@ fn modify_zone(zone: &mut Zone, time_diff: u64) {
                     }
                 };
 
-                zone.radius = new_radius
-                    .max(zone_modification.min_radius)
-                    .min(zone_modification.max_radius);
+                zone.radius =
+                    new_radius.clamp(zone_modification.min_radius, zone_modification.max_radius);
             }
         }
         _ => {

--- a/native/game_backend/src/lib.rs
+++ b/native/game_backend/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)] // rustler macros generate non snake case names and dont use this allow themselves
+
 mod character;
 mod config;
 mod effect;

--- a/native/game_backend/src/map.rs
+++ b/native/game_backend/src/map.rs
@@ -53,8 +53,8 @@ pub fn next_position(
     width: f32,
 ) -> Position {
     let angle_rad = direction_angle * (PI / 180.0);
-    let new_x = (current_position.x as f32) + movement_amount * angle_rad.cos();
-    let new_y = (current_position.y as f32) + movement_amount * angle_rad.sin();
+    let new_x = movement_amount.mul_add(angle_rad.cos(), current_position.x as f32);
+    let new_y = movement_amount.mul_add(angle_rad.sin(), current_position.y as f32);
 
     // This is to avoid  the overflow on the front end
     let radius = (width - 200.0) / 2.0;
@@ -78,7 +78,7 @@ pub fn next_position(
     }
 }
 
-pub fn collision_with_edge(center: &Position, size: u64, width: u64, height: u64) -> bool {
+pub const fn collision_with_edge(center: &Position, size: u64, width: u64, height: u64) -> bool {
     let x_edge_positive = (width / 2) as i64;
     let x_position_positive = center.x + size as i64;
     if x_position_positive >= x_edge_positive {

--- a/native/game_backend/src/player.rs
+++ b/native/game_backend/src/player.rs
@@ -35,7 +35,7 @@ pub struct Player {
     next_actions: Vec<Action>,
 }
 
-#[derive(NifTaggedEnum, Clone, PartialEq)]
+#[derive(NifTaggedEnum, Clone, PartialEq, Eq)]
 pub enum PlayerStatus {
     Alive,
     Death,

--- a/priv/static/assets/js/app.js
+++ b/priv/static/assets/js/app.js
@@ -1599,12 +1599,16 @@
   var PHX_PRUNE = "data-phx-prune";
   var PHX_PAGE_LOADING = "page-loading";
   var PHX_CONNECTED_CLASS = "phx-connected";
-  var PHX_DISCONNECTED_CLASS = "phx-loading";
+  var PHX_LOADING_CLASS = "phx-loading";
   var PHX_NO_FEEDBACK_CLASS = "phx-no-feedback";
   var PHX_ERROR_CLASS = "phx-error";
+  var PHX_CLIENT_ERROR_CLASS = "phx-client-error";
+  var PHX_SERVER_ERROR_CLASS = "phx-server-error";
   var PHX_PARENT_ID = "data-phx-parent-id";
   var PHX_MAIN = "data-phx-main";
   var PHX_ROOT_ID = "data-phx-root-id";
+  var PHX_VIEWPORT_TOP = "viewport-top";
+  var PHX_VIEWPORT_BOTTOM = "viewport-bottom";
   var PHX_TRIGGER_ACTION = "trigger-action";
   var PHX_FEEDBACK_FOR = "feedback-for";
   var PHX_HAS_FOCUSED = "phx-has-focused";
@@ -1624,6 +1628,7 @@
   var PHX_THROTTLE = "throttle";
   var PHX_UPDATE = "update";
   var PHX_STREAM = "stream";
+  var PHX_STREAM_REF = "data-phx-stream";
   var PHX_KEY = "key";
   var PHX_PRIVATE = "phxPrivate";
   var PHX_AUTO_RECOVER = "auto-recover";
@@ -1658,11 +1663,15 @@
       this.offset = 0;
       this.chunkSize = chunkSize;
       this.chunkTimer = null;
+      this.errored = false;
       this.uploadChannel = liveSocket2.channel(`lvu:${entry.ref}`, { token: entry.metadata() });
     }
     error(reason) {
+      if (this.errored) {
+        return;
+      }
+      this.errored = true;
       clearTimeout(this.chunkTimer);
-      this.uploadChannel.leave();
       this.entry.error(reason);
     }
     upload() {
@@ -1694,7 +1703,7 @@
         if (!this.isDone()) {
           this.chunkTimer = setTimeout(() => this.readNextChunk(), this.liveSocket.getLatencySim() || 0);
         }
-      });
+      }).receive("error", ({ reason }) => this.error(reason));
     }
   };
   var logError = (msg, obj) => console.error && console.error(msg, obj);
@@ -1843,6 +1852,9 @@
     isUploadInput(el) {
       return el.type === "file" && el.getAttribute(PHX_UPLOAD_REF) !== null;
     },
+    isAutoUpload(inputEl) {
+      return inputEl.hasAttribute("data-phx-auto-upload");
+    },
     findUploadInputs(node) {
       return this.all(node, `input[type="file"][${PHX_UPLOAD_REF}]`);
     },
@@ -1854,19 +1866,36 @@
     },
     wantsNewTab(e) {
       let wantsNewTab = e.ctrlKey || e.shiftKey || e.metaKey || e.button && e.button === 1;
-      return wantsNewTab || e.target.getAttribute("target") === "_blank";
+      let isDownload = e.target instanceof HTMLAnchorElement && e.target.hasAttribute("download");
+      let isTargetBlank = e.target.hasAttribute("target") && e.target.getAttribute("target").toLowerCase() === "_blank";
+      return wantsNewTab || isTargetBlank || isDownload;
     },
     isUnloadableFormSubmit(e) {
-      return !e.defaultPrevented && !this.wantsNewTab(e);
+      let isDialogSubmit = e.target && e.target.getAttribute("method") === "dialog" || e.submitter && e.submitter.getAttribute("formmethod") === "dialog";
+      if (isDialogSubmit) {
+        return false;
+      } else {
+        return !e.defaultPrevented && !this.wantsNewTab(e);
+      }
     },
-    isNewPageHref(href, currentLocation) {
+    isNewPageClick(e, currentLocation) {
+      let href = e.target instanceof HTMLAnchorElement ? e.target.getAttribute("href") : null;
       let url;
+      if (e.defaultPrevented || href === null || this.wantsNewTab(e)) {
+        return false;
+      }
+      if (href.startsWith("mailto:") || href.startsWith("tel:")) {
+        return false;
+      }
+      if (e.target.isContentEditable) {
+        return false;
+      }
       try {
         url = new URL(href);
-      } catch (e) {
+      } catch (e2) {
         try {
           url = new URL(href, currentLocation);
-        } catch (e2) {
+        } catch (e3) {
           return true;
         }
       }
@@ -1875,7 +1904,7 @@
           return url.hash === "" && !url.href.endsWith("#");
         }
       }
-      return true;
+      return url.protocol.startsWith("http");
     },
     markPhxChildDestroyed(el) {
       if (this.isPhxChild(el)) {
@@ -2049,14 +2078,19 @@
       this.putPrivate(el, key, [currentCycle, trigger]);
       return currentCycle;
     },
-    discardError(container, el, phxFeedbackFor) {
-      let field = el.getAttribute && el.getAttribute(phxFeedbackFor);
-      let input = field && container.querySelector(`[id="${field}"], [name="${field}"], [name="${field}[]"]`);
-      if (!input) {
-        return;
+    maybeAddPrivateHooks(el, phxViewportTop, phxViewportBottom) {
+      if (el.hasAttribute && (el.hasAttribute(phxViewportTop) || el.hasAttribute(phxViewportBottom))) {
+        el.setAttribute("data-phx-hook", "Phoenix.InfiniteScroll");
       }
+    },
+    maybeHideFeedback(container, input, phxFeedbackFor) {
       if (!(this.private(input, PHX_HAS_FOCUSED) || this.private(input, PHX_HAS_SUBMITTED))) {
-        el.classList.add(PHX_NO_FEEDBACK_CLASS);
+        let feedbacks = [input.name];
+        if (input.name.endsWith("[]")) {
+          feedbacks.push(input.name.slice(0, -2));
+        }
+        let selector = feedbacks.map((f) => `[${phxFeedbackFor}="${f}"]`).join(", ");
+        DOM.all(container, selector, (el) => el.classList.add(PHX_NO_FEEDBACK_CLASS));
       }
     },
     resetForm(form, phxFeedbackFor) {
@@ -2316,7 +2350,9 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     error(reason = "failed") {
       this.fileEl.removeEventListener(PHX_LIVE_FILE_UPDATED, this._onElUpdated);
       this.view.pushFileProgress(this.fileEl, this.ref, { error: reason });
-      LiveUploader.clearFiles(this.fileEl);
+      if (!dom_default.isAutoUpload(this.fileEl)) {
+        LiveUploader.clearFiles(this.fileEl);
+      }
     }
     onDone(callback) {
       this._onDone = () => {
@@ -2337,7 +2373,8 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
         relative_path: this.file.webkitRelativePath,
         size: this.file.size,
         type: this.file.type,
-        ref: this.ref
+        ref: this.ref,
+        meta: typeof this.file.meta === "function" ? this.file.meta() : void 0
       };
     }
     uploader(uploaders) {
@@ -2392,6 +2429,9 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
         entry.relative_path = file.webkitRelativePath;
         entry.type = file.type;
         entry.size = file.size;
+        if (typeof file.meta === "function") {
+          entry.meta = file.meta();
+        }
         fileData[uploadRef].push(entry);
       });
       return fileData;
@@ -2451,6 +2491,9 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
         return entry;
       });
       let groupedEntries = this._entries.reduce((acc, entry) => {
+        if (!entry.meta) {
+          return acc;
+        }
         let { name, callback } = entry.uploader(liveSocket2.uploaders);
         acc[name] = acc[name] || { callback, entries: [] };
         acc[name].entries.push(entry);
@@ -2565,6 +2608,104 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
           aria_default.focusFirst(this.el);
         }
       }
+    }
+  };
+  var scrollTop = () => document.documentElement.scrollTop || document.body.scrollTop;
+  var winHeight = () => window.innerHeight || document.documentElement.clientHeight;
+  var isAtViewportTop = (el) => {
+    let rect = el.getBoundingClientRect();
+    return rect.top >= 0 && rect.left >= 0 && rect.top <= winHeight();
+  };
+  var isAtViewportBottom = (el) => {
+    let rect = el.getBoundingClientRect();
+    return rect.right >= 0 && rect.left >= 0 && rect.bottom <= winHeight();
+  };
+  var isWithinViewport = (el) => {
+    let rect = el.getBoundingClientRect();
+    return rect.top >= 0 && rect.left >= 0 && rect.top <= winHeight();
+  };
+  Hooks.InfiniteScroll = {
+    mounted() {
+      let scrollBefore = scrollTop();
+      let topOverran = false;
+      let throttleInterval = 500;
+      let pendingOp = null;
+      let onTopOverrun = this.throttle(throttleInterval, (topEvent, firstChild) => {
+        pendingOp = () => true;
+        this.liveSocket.execJSHookPush(this.el, topEvent, { id: firstChild.id, _overran: true }, () => {
+          pendingOp = null;
+        });
+      });
+      let onFirstChildAtTop = this.throttle(throttleInterval, (topEvent, firstChild) => {
+        pendingOp = () => firstChild.scrollIntoView({ block: "start" });
+        this.liveSocket.execJSHookPush(this.el, topEvent, { id: firstChild.id }, () => {
+          pendingOp = null;
+          if (!isWithinViewport(firstChild)) {
+            firstChild.scrollIntoView({ block: "start" });
+          }
+        });
+      });
+      let onLastChildAtBottom = this.throttle(throttleInterval, (bottomEvent, lastChild) => {
+        pendingOp = () => lastChild.scrollIntoView({ block: "end" });
+        this.liveSocket.execJSHookPush(this.el, bottomEvent, { id: lastChild.id }, () => {
+          pendingOp = null;
+          if (!isWithinViewport(lastChild)) {
+            lastChild.scrollIntoView({ block: "end" });
+          }
+        });
+      });
+      this.onScroll = (e) => {
+        let scrollNow = scrollTop();
+        if (pendingOp) {
+          scrollBefore = scrollNow;
+          return pendingOp();
+        }
+        let rect = this.el.getBoundingClientRect();
+        let topEvent = this.el.getAttribute(this.liveSocket.binding("viewport-top"));
+        let bottomEvent = this.el.getAttribute(this.liveSocket.binding("viewport-bottom"));
+        let lastChild = this.el.lastElementChild;
+        let firstChild = this.el.firstElementChild;
+        let isScrollingUp = scrollNow < scrollBefore;
+        let isScrollingDown = scrollNow > scrollBefore;
+        if (isScrollingUp && topEvent && !topOverran && rect.top >= 0) {
+          topOverran = true;
+          onTopOverrun(topEvent, firstChild);
+        } else if (isScrollingDown && topOverran && rect.top <= 0) {
+          topOverran = false;
+        }
+        if (topEvent && isScrollingUp && isAtViewportTop(firstChild)) {
+          onFirstChildAtTop(topEvent, firstChild);
+        } else if (bottomEvent && isScrollingDown && isAtViewportBottom(lastChild)) {
+          onLastChildAtBottom(bottomEvent, lastChild);
+        }
+        scrollBefore = scrollNow;
+      };
+      window.addEventListener("scroll", this.onScroll);
+    },
+    destroyed() {
+      window.removeEventListener("scroll", this.onScroll);
+    },
+    throttle(interval, callback) {
+      let lastCallAt = 0;
+      let timer;
+      return (...args) => {
+        let now = Date.now();
+        let remainingTime = interval - (now - lastCallAt);
+        if (remainingTime <= 0 || remainingTime > interval) {
+          if (timer) {
+            clearTimeout(timer);
+            timer = null;
+          }
+          lastCallAt = now;
+          callback(...args);
+        } else if (!timer) {
+          timer = setTimeout(() => {
+            lastCallAt = Date.now();
+            timer = null;
+            callback(...args);
+          }, remainingTime);
+        }
+      };
     }
   };
   var hooks_default = Hooks;
@@ -3160,8 +3301,11 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       let phxUpdate = liveSocket2.binding(PHX_UPDATE);
       let phxFeedbackFor = liveSocket2.binding(PHX_FEEDBACK_FOR);
       let disableWith = liveSocket2.binding(PHX_DISABLE_WITH);
+      let phxViewportTop = liveSocket2.binding(PHX_VIEWPORT_TOP);
+      let phxViewportBottom = liveSocket2.binding(PHX_VIEWPORT_BOTTOM);
       let phxTriggerExternal = liveSocket2.binding(PHX_TRIGGER_ACTION);
       let added = [];
+      let trackedInputs = [];
       let updates = [];
       let appendPrependUpdates = [];
       let externalFormTriggered = null;
@@ -3171,15 +3315,21 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       this.trackBefore("added", container);
       this.trackBefore("updated", container, container);
       liveSocket2.time("morphdom", () => {
-        this.streams.forEach(([inserts, deleteIds]) => {
-          this.streamInserts = Object.assign(this.streamInserts, inserts);
+        this.streams.forEach(([ref, inserts, deleteIds, reset]) => {
+          Object.entries(inserts).forEach(([key, [streamAt, limit]]) => {
+            this.streamInserts[key] = { ref, streamAt, limit };
+          });
+          if (reset !== void 0) {
+            dom_default.all(container, `[${PHX_STREAM_REF}="${ref}"]`, (child) => {
+              if (!inserts[child.id]) {
+                this.removeStreamChildElement(child);
+              }
+            });
+          }
           deleteIds.forEach((id) => {
             let child = container.querySelector(`[id="${id}"]`);
             if (child) {
-              if (!this.maybePendingRemove(child)) {
-                child.remove();
-                this.onNodeDiscarded(child);
-              }
+              this.removeStreamChildElement(child);
             }
           });
         });
@@ -3192,10 +3342,11 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
             return from.getAttribute(phxUpdate) === PHX_STREAM;
           },
           addChild: (parent, child) => {
-            let streamAt = child.id ? this.streamInserts[child.id] : void 0;
-            if (streamAt === void 0) {
+            let { ref, streamAt, limit } = this.getStreamInsert(child);
+            if (ref === void 0) {
               return parent.appendChild(child);
             }
+            dom_default.putSticky(child, PHX_STREAM_REF, (el) => el.setAttribute(PHX_STREAM_REF, ref));
             if (streamAt === 0) {
               parent.insertAdjacentElement("afterbegin", child);
             } else if (streamAt === -1) {
@@ -3204,12 +3355,28 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
               let sibling = Array.from(parent.children)[streamAt];
               parent.insertBefore(child, sibling);
             }
+            let children = limit !== null && Array.from(parent.children);
+            let childrenToRemove = [];
+            if (limit && limit < 0 && children.length > limit * -1) {
+              childrenToRemove = children.slice(0, children.length + limit);
+            } else if (limit && limit >= 0 && children.length > limit) {
+              childrenToRemove = children.slice(limit);
+            }
+            childrenToRemove.forEach((removeChild) => {
+              if (!this.streamInserts[removeChild.id]) {
+                this.removeStreamChildElement(removeChild);
+              }
+            });
           },
           onBeforeNodeAdded: (el) => {
+            dom_default.maybeAddPrivateHooks(el, phxViewportTop, phxViewportBottom);
             this.trackBefore("added", el);
             return el;
           },
           onNodeAdded: (el) => {
+            if (el.getAttribute) {
+              this.maybeReOrderStream(el);
+            }
             if (el instanceof HTMLImageElement && el.srcset) {
               el.srcset = el.srcset;
             } else if (el instanceof HTMLVideoElement && el.autoplay) {
@@ -3218,7 +3385,9 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
             if (dom_default.isNowTriggerFormExternal(el, phxTriggerExternal)) {
               externalFormTriggered = el;
             }
-            dom_default.discardError(targetContainer, el, phxFeedbackFor);
+            if (el.getAttribute && el.getAttribute("name") && dom_default.isFormInput(el)) {
+              trackedInputs.push(el);
+            }
             if (dom_default.isPhxChild(el) && view.ownsElement(el) || dom_default.isPhxSticky(el) && view.ownsElement(el.parentNode)) {
               this.trackAfter("phxChildAdded", el);
             }
@@ -3248,6 +3417,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
             this.maybeReOrderStream(el);
           },
           onBeforeElUpdated: (fromEl, toEl) => {
+            dom_default.maybeAddPrivateHooks(toEl, phxViewportTop, phxViewportBottom);
             dom_default.cleanChildNodes(toEl, phxUpdate);
             if (this.skipCIDSibling(toEl)) {
               return false;
@@ -3284,7 +3454,6 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
               return false;
             }
             dom_default.copyPrivates(toEl, fromEl);
-            dom_default.discardError(targetContainer, toEl, phxFeedbackFor);
             let isFocusedFormEl = focused && fromEl.isSameNode(focused) && dom_default.isFormInput(fromEl);
             if (isFocusedFormEl && fromEl.type !== "hidden") {
               this.trackBefore("updated", fromEl, toEl);
@@ -3292,6 +3461,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
               dom_default.syncAttrsToProps(fromEl);
               updates.push(fromEl);
               dom_default.applyStickyOperations(fromEl);
+              trackedInputs.push(fromEl);
               return false;
             } else {
               if (dom_default.isPhxUpdate(toEl, phxUpdate, ["append", "prepend"])) {
@@ -3299,6 +3469,9 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
               }
               dom_default.syncAttrsToProps(toEl);
               dom_default.applyStickyOperations(toEl);
+              if (toEl.getAttribute("name") && dom_default.isFormInput(toEl)) {
+                trackedInputs.push(toEl);
+              }
               this.trackBefore("updated", fromEl, toEl);
               return true;
             }
@@ -3313,6 +3486,9 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
           appendPrependUpdates.forEach((update) => update.perform());
         });
       }
+      trackedInputs.forEach((input) => {
+        dom_default.maybeHideFeedback(targetContainer, input, phxFeedbackFor);
+      });
       liveSocket2.silenceEvents(() => dom_default.restoreFocus(focused, selectionStart, selectionEnd));
       dom_default.dispatchEvent(document, "phx:update");
       added.forEach((el) => this.trackAfter("added", el));
@@ -3320,7 +3496,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       this.transitionPendingRemoves();
       if (externalFormTriggered) {
         liveSocket2.unload();
-        externalFormTriggered.submit();
+        Object.getPrototypeOf(externalFormTriggered).submit.call(externalFormTriggered);
       }
       return true;
     }
@@ -3338,11 +3514,22 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
         return false;
       }
     }
+    removeStreamChildElement(child) {
+      if (!this.maybePendingRemove(child)) {
+        child.remove();
+        this.onNodeDiscarded(child);
+      }
+    }
+    getStreamInsert(el) {
+      let insert = el.id ? this.streamInserts[el.id] : {};
+      return insert || {};
+    }
     maybeReOrderStream(el) {
-      let streamAt = el.id ? this.streamInserts[el.id] : void 0;
+      let { ref, streamAt, limit } = this.getStreamInsert(el);
       if (streamAt === void 0) {
         return;
       }
+      dom_default.putSticky(el, PHX_STREAM_REF, (el2) => el2.setAttribute(PHX_STREAM_REF, ref));
       if (streamAt === 0) {
         el.parentElement.insertBefore(el, el.parentElement.firstElementChild);
       } else if (streamAt > 0) {
@@ -3529,7 +3716,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       return merged;
     }
     componentToString(cid) {
-      let [str, streams] = this.recursiveCIDToString(this.rendered[COMPONENTS], cid);
+      let [str, streams] = this.recursiveCIDToString(this.rendered[COMPONENTS], cid, null, false);
       return [str, streams];
     }
     pruneCIDs(cids) {
@@ -3562,7 +3749,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     }
     comprehensionToBuffer(rendered, templates, output) {
       let { [DYNAMICS]: dynamics, [STATIC]: statics, [STREAM]: stream } = rendered;
-      let [_inserts, deleteIds] = stream || [{}, []];
+      let [_ref, _inserts, deleteIds, reset] = stream || [null, {}, [], null];
       statics = this.templateStatic(statics, templates);
       let compTemplates = templates || rendered[TEMPLATES];
       for (let d = 0; d < dynamics.length; d++) {
@@ -3573,7 +3760,8 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
           output.buffer += statics[i];
         }
       }
-      if (stream !== void 0 && (rendered[DYNAMICS].length > 0 || deleteIds.length > 0)) {
+      if (stream !== void 0 && (rendered[DYNAMICS].length > 0 || deleteIds.length > 0 || reset)) {
+        delete rendered[STREAM];
         rendered[DYNAMICS] = [];
         output.streams.add(stream);
       }
@@ -3589,7 +3777,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
         output.buffer += rendered;
       }
     }
-    recursiveCIDToString(components, cid, onlyCids) {
+    recursiveCIDToString(components, cid, onlyCids, allowRootComments = true) {
       let component = components[cid] || logError(`no component for CID ${cid}`, components);
       let template = document.createElement("template");
       let [html, streams] = this.recursiveToString(component, components, onlyCids);
@@ -3610,6 +3798,11 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
             child.innerHTML = "";
           }
           return [true, hasComponents];
+        } else if (child.nodeType === Node.COMMENT_NODE) {
+          if (!allowRootComments) {
+            child.remove();
+          }
+          return [hasNodes, hasComponents];
         } else {
           if (child.nodeValue.trim() !== "") {
             logError(`only HTML element tags are allowed at the root of components.
@@ -3687,12 +3880,12 @@ within:
     }
     pushEvent(event, payload = {}, onReply = function() {
     }) {
-      return this.__view.pushHookEvent(null, event, payload, onReply);
+      return this.__view.pushHookEvent(this.el, null, event, payload, onReply);
     }
     pushEventTo(phxTarget, event, payload = {}, onReply = function() {
     }) {
       return this.__view.withinTargets(phxTarget, (view, targetCtx) => {
-        return view.pushHookEvent(targetCtx, event, payload, onReply);
+        return view.pushHookEvent(this.el, targetCtx, event, payload, onReply);
       });
     }
     handleEvent(event, callback) {
@@ -3707,10 +3900,12 @@ within:
       this.__listeners.delete(callbackRef);
     }
     upload(name, files) {
-      return this.__view.dispatchUploads(name, files);
+      return this.__view.dispatchUploads(null, name, files);
     }
     uploadTo(phxTarget, name, files) {
-      return this.__view.withinTargets(phxTarget, (view) => view.dispatchUploads(name, files));
+      return this.__view.withinTargets(phxTarget, (view, targetCtx) => {
+        view.dispatchUploads(targetCtx, name, files);
+      });
     }
     __cleanup__() {
       this.__listeners.forEach((callbackRef) => this.removeHandleEvent(callbackRef));
@@ -3719,11 +3914,12 @@ within:
   var focusStack = null;
   var JS = {
     exec(eventType, phxEvent, view, sourceEl, defaults) {
-      let [defaultKind, defaultArgs] = defaults || [null, {}];
+      let [defaultKind, defaultArgs] = defaults || [null, { callback: defaults && defaults.callback }];
       let commands = phxEvent.charAt(0) === "[" ? JSON.parse(phxEvent) : [[defaultKind, defaultArgs]];
       commands.forEach(([kind, args]) => {
         if (kind === defaultKind && defaultArgs.data) {
           args.data = Object.assign(args.data || {}, defaultArgs.data);
+          args.callback = args.callback || defaultArgs.callback;
         }
         this.filterToEls(sourceEl, args).forEach((el) => {
           this[`exec_${kind}`](eventType, phxEvent, view, sourceEl, el, args);
@@ -3752,13 +3948,13 @@ within:
       if (!view.isConnected()) {
         return;
       }
-      let { event, data, target, page_loading, loading, value, dispatcher } = args;
+      let { event, data, target, page_loading, loading, value, dispatcher, callback } = args;
       let pushOpts = { loading, value, target, page_loading: !!page_loading };
       let targetSrc = eventType === "change" && dispatcher ? dispatcher : sourceEl;
       let phxTarget = target || targetSrc.getAttribute(view.binding("target")) || targetSrc;
       view.withinTargets(phxTarget, (targetView, targetCtx) => {
         if (eventType === "change") {
-          let { newCid, _target, callback } = args;
+          let { newCid, _target } = args;
           _target = _target || (dom_default.isFormInput(sourceEl) ? sourceEl.name : void 0);
           if (_target) {
             pushOpts._target = _target;
@@ -3766,9 +3962,9 @@ within:
           targetView.pushInput(sourceEl, targetCtx, newCid, event || phxEvent, pushOpts, callback);
         } else if (eventType === "submit") {
           let { submitter } = args;
-          targetView.submitForm(sourceEl, targetCtx, event || phxEvent, submitter, pushOpts);
+          targetView.submitForm(sourceEl, targetCtx, event || phxEvent, submitter, pushOpts, callback);
         } else {
-          targetView.pushEvent(eventType, sourceEl, targetCtx, event || phxEvent, data, pushOpts);
+          targetView.pushEvent(eventType, sourceEl, targetCtx, event || phxEvent, data, pushOpts, callback);
         }
       });
     },
@@ -3884,10 +4080,16 @@ within:
       }
     },
     addOrRemoveClasses(el, adds, removes, transition, time, view) {
-      let [transition_run, transition_start, transition_end] = transition || [[], [], []];
-      if (transition_run.length > 0) {
-        let onStart = () => this.addOrRemoveClasses(el, transition_start.concat(transition_run), []);
-        let onDone = () => this.addOrRemoveClasses(el, adds.concat(transition_end), removes.concat(transition_run).concat(transition_start));
+      let [transitionRun, transitionStart, transitionEnd] = transition || [[], [], []];
+      if (transitionRun.length > 0) {
+        let onStart = () => {
+          this.addOrRemoveClasses(el, transitionStart, [].concat(transitionRun).concat(transitionEnd));
+          window.requestAnimationFrame(() => {
+            this.addOrRemoveClasses(el, transitionRun, []);
+            window.requestAnimationFrame(() => this.addOrRemoveClasses(el, transitionEnd, transitionStart));
+          });
+        };
+        let onDone = () => this.addOrRemoveClasses(el, adds.concat(transitionEnd), removes.concat(transitionRun).concat(transitionStart));
         return view.transition(time, onStart, onDone);
       }
       window.requestAnimationFrame(() => {
@@ -3983,9 +4185,10 @@ within:
       this.children = this.parent ? null : {};
       this.root.children[this.id] = {};
       this.channel = this.liveSocket.channel(`lv:${this.id}`, () => {
+        let url = this.href && this.expandURL(this.href);
         return {
-          redirect: this.redirect ? this.href : void 0,
-          url: this.redirect ? void 0 : this.href || void 0,
+          redirect: this.redirect ? url : void 0,
+          url: this.redirect ? void 0 : url || void 0,
           params: this.connectParams(liveReferer),
           session: this.getSession(),
           static: this.getStatic(),
@@ -4043,7 +4246,7 @@ within:
       this.channel.leave().receive("ok", onFinished).receive("error", onFinished).receive("timeout", onFinished);
     }
     setContainerClasses(...classes) {
-      this.el.classList.remove(PHX_CONNECTED_CLASS, PHX_DISCONNECTED_CLASS, PHX_ERROR_CLASS);
+      this.el.classList.remove(PHX_CONNECTED_CLASS, PHX_LOADING_CLASS, PHX_ERROR_CLASS, PHX_CLIENT_ERROR_CLASS, PHX_SERVER_ERROR_CLASS);
       this.el.classList.add(...classes);
     }
     showLoader(timeout) {
@@ -4054,7 +4257,7 @@ within:
         for (let id in this.viewHooks) {
           this.viewHooks[id].__disconnected();
         }
-        this.setContainerClasses(PHX_DISCONNECTED_CLASS);
+        this.setContainerClasses(PHX_LOADING_CLASS);
       }
     }
     execAll(binding) {
@@ -4168,6 +4371,12 @@ within:
       this.el.setAttribute(PHX_ROOT_ID, this.root.id);
     }
     execNewMounted() {
+      let phxViewportTop = this.binding(PHX_VIEWPORT_TOP);
+      let phxViewportBottom = this.binding(PHX_VIEWPORT_BOTTOM);
+      dom_default.all(this.el, `[${phxViewportTop}], [${phxViewportBottom}]`, (hookEl) => {
+        dom_default.maybeAddPrivateHooks(hookEl, phxViewportTop, phxViewportBottom);
+        this.maybeAddNewHook(hookEl);
+      });
       dom_default.all(this.el, `[${this.binding(PHX_HOOK)}], [data-phx-${PHX_HOOK}]`, (hookEl) => {
         this.maybeAddNewHook(hookEl);
       });
@@ -4480,10 +4689,16 @@ within:
     onJoinError(resp) {
       if (resp.reason === "reload") {
         this.log("error", () => [`failed mount with ${resp.status}. Falling back to page request`, resp]);
-        return this.onRedirect({ to: this.href });
+        if (this.isMain()) {
+          this.onRedirect({ to: this.href });
+        }
+        return;
       } else if (resp.reason === "unauthorized" || resp.reason === "stale") {
         this.log("error", () => ["unauthorized live_redirect. Falling back to page request", resp]);
-        return this.onRedirect({ to: this.href });
+        if (this.isMain()) {
+          this.onRedirect({ to: this.href });
+        }
+        return;
       }
       if (resp.redirect || resp.live_redirect) {
         this.joinPending = false;
@@ -4495,6 +4710,7 @@ within:
       if (resp.live_redirect) {
         return this.onLiveRedirect(resp.live_redirect);
       }
+      this.displayError([PHX_LOADING_CLASS, PHX_ERROR_CLASS, PHX_SERVER_ERROR_CLASS]);
       this.log("error", () => ["unable to join", resp]);
       if (this.liveSocket.isConnected()) {
         this.liveSocket.reloadWithJitter(this);
@@ -4522,15 +4738,19 @@ within:
         this.log("error", () => ["view crashed", reason]);
       }
       if (!this.liveSocket.isUnloaded()) {
-        this.displayError();
+        if (this.liveSocket.isConnected()) {
+          this.displayError([PHX_LOADING_CLASS, PHX_ERROR_CLASS, PHX_SERVER_ERROR_CLASS]);
+        } else {
+          this.displayError([PHX_LOADING_CLASS, PHX_ERROR_CLASS, PHX_CLIENT_ERROR_CLASS]);
+        }
       }
     }
-    displayError() {
+    displayError(classes) {
       if (this.isMain()) {
         dom_default.dispatchEvent(window, "phx:page-loading-start", { detail: { to: this.href, kind: "error" } });
       }
       this.showLoader();
-      this.setContainerClasses(PHX_DISCONNECTED_CLASS, PHX_ERROR_CLASS);
+      this.setContainerClasses(...classes);
       this.execAll(this.binding("disconnected"));
     }
     pushWithReply(refGenerator, event, payload, onReply = function() {
@@ -4559,20 +4779,23 @@ within:
             if (resp.live_redirect) {
               this.onLiveRedirect(resp.live_redirect);
             }
-            if (ref !== null) {
-              this.undoRefs(ref);
-            }
             onLoadingDone();
             onReply(resp, hookReply);
           };
           if (resp.diff) {
             this.liveSocket.requestDOMUpdate(() => {
               this.applyDiff("update", resp.diff, ({ diff, reply, events }) => {
+                if (ref !== null) {
+                  this.undoRefs(ref);
+                }
                 this.update(diff, events);
                 finish(reply);
               });
             });
           } else {
+            if (ref !== null) {
+              this.undoRefs(ref);
+            }
             finish(null);
           }
         });
@@ -4660,12 +4883,12 @@ within:
         return null;
       }
     }
-    pushHookEvent(targetCtx, event, payload, onReply) {
+    pushHookEvent(el, targetCtx, event, payload, onReply) {
       if (!this.isConnected()) {
         this.log("hook", () => ["unable to push hook event. LiveView not connected", event, payload]);
         return false;
       }
-      let [ref, els, opts] = this.putRef([], "hook");
+      let [ref, els, opts] = this.putRef([el], "hook");
       this.pushWithReply(() => [ref, els, opts], "event", {
         type: "hook",
         event,
@@ -4685,7 +4908,7 @@ within:
           meta[name.replace(prefix, "")] = el.getAttribute(name);
         }
       }
-      if (el.value !== void 0) {
+      if (el.value !== void 0 && !(el instanceof HTMLFormElement)) {
         if (!meta) {
           meta = {};
         }
@@ -4704,13 +4927,13 @@ within:
       }
       return meta;
     }
-    pushEvent(type, el, targetCtx, phxEvent, meta, opts = {}) {
+    pushEvent(type, el, targetCtx, phxEvent, meta, opts = {}, onReply) {
       this.pushWithReply(() => this.putRef([el], type, opts), "event", {
         type,
         event: phxEvent,
         value: this.extractMeta(el, meta, opts.value),
         cid: this.targetComponentID(el, targetCtx, opts)
-      });
+      }, (resp, reply) => onReply && onReply(reply));
     }
     pushFileProgress(fileEl, entryRef, progress, onReply = function() {
     }) {
@@ -4729,10 +4952,11 @@ within:
       let cid = isCid(forceCid) ? forceCid : this.targetComponentID(inputEl.form, targetCtx);
       let refGenerator = () => this.putRef([inputEl, inputEl.form], "change", opts);
       let formData;
+      let meta = this.extractMeta(inputEl.form);
       if (inputEl.getAttribute(this.binding("change"))) {
-        formData = serializeForm(inputEl.form, { _target: opts._target }, [inputEl.name]);
+        formData = serializeForm(inputEl.form, __spreadValues({ _target: opts._target }, meta), [inputEl.name]);
       } else {
-        formData = serializeForm(inputEl.form, { _target: opts._target });
+        formData = serializeForm(inputEl.form, __spreadValues({ _target: opts._target }, meta));
       }
       if (dom_default.isUploadInput(inputEl) && inputEl.files && inputEl.files.length > 0) {
         LiveUploader.trackFiles(inputEl, Array.from(inputEl.files));
@@ -4747,7 +4971,7 @@ within:
       };
       this.pushWithReply(refGenerator, "event", event, (resp) => {
         dom_default.showError(inputEl, this.liveSocket.binding(PHX_FEEDBACK_FOR));
-        if (dom_default.isUploadInput(inputEl) && inputEl.getAttribute("data-phx-auto-upload") !== null) {
+        if (dom_default.isUploadInput(inputEl) && dom_default.isAutoUpload(inputEl)) {
           if (LiveUploader.filesAwaitingPreflight(inputEl).length > 0) {
             let [ref, _els] = refGenerator();
             this.uploadFiles(inputEl.form, targetCtx, ref, cid, (_uploads) => {
@@ -4827,7 +5051,8 @@ within:
         let [ref, els] = refGenerator();
         let proxyRefGen = () => [ref, els, opts];
         this.uploadFiles(formEl, targetCtx, ref, cid, (_uploads) => {
-          let formData = serializeForm(formEl, { submitter });
+          let meta = this.extractMeta(formEl);
+          let formData = serializeForm(formEl, __spreadValues({ submitter }, meta));
           this.pushWithReply(proxyRefGen, "event", {
             type: "form",
             event: phxEvent,
@@ -4835,8 +5060,9 @@ within:
             cid
           }, onReply);
         });
-      } else {
-        let formData = serializeForm(formEl, { submitter });
+      } else if (!(formEl.hasAttribute(PHX_REF) && formEl.classList.contains("phx-submit-loading"))) {
+        let meta = this.extractMeta(formEl);
+        let formData = serializeForm(formEl, __spreadValues({ submitter }, meta));
         this.pushWithReply(refGenerator, "event", {
           type: "form",
           event: phxEvent,
@@ -4883,8 +5109,9 @@ within:
         });
       });
     }
-    dispatchUploads(name, filesOrBlobs) {
-      let inputs = dom_default.findUploadInputs(this.el).filter((el) => el.name === name);
+    dispatchUploads(targetCtx, name, filesOrBlobs) {
+      let targetElement = this.targetCtxElement(targetCtx) || this.el;
+      let inputs = dom_default.findUploadInputs(targetElement).filter((el) => el.name === name);
       if (inputs.length === 0) {
         logError(`no live file inputs found matching the name "${name}"`);
       } else if (inputs.length > 1) {
@@ -4893,11 +5120,25 @@ within:
         dom_default.dispatchEvent(inputs[0], PHX_TRACK_UPLOADS, { detail: { files: filesOrBlobs } });
       }
     }
+    targetCtxElement(targetCtx) {
+      if (isCid(targetCtx)) {
+        let [target] = dom_default.findComponentNodeList(this.el, targetCtx);
+        return target;
+      } else if (targetCtx) {
+        return targetCtx;
+      } else {
+        return null;
+      }
+    }
     pushFormRecovery(form, newCid, callback) {
       this.liveSocket.withinOwners(form, (view, targetCtx) => {
-        let input = Array.from(form.elements).find((el) => {
-          return dom_default.isFormInput(el) && el.type !== "hidden" && !el.hasAttribute(this.binding("change"));
-        });
+        let phxChange = this.binding("change");
+        let inputs = Array.from(form.elements).filter((el) => dom_default.isFormInput(el) && el.name && !el.hasAttribute(phxChange));
+        if (inputs.length === 0) {
+          return;
+        }
+        inputs.forEach((input2) => input2.hasAttribute(PHX_UPLOAD_REF) && LiveUploader.clearFiles(input2));
+        let input = inputs.find((el) => el.type !== "hidden") || inputs[0];
         let phxEvent = form.getAttribute(this.binding(PHX_AUTO_RECOVER)) || form.getAttribute(this.binding("change"));
         js_default.exec("change", phxEvent, view, input, ["push", { _target: input.name, newCid, callback }]);
       });
@@ -4906,7 +5147,8 @@ within:
       let linkRef = this.liveSocket.setPendingLink(href);
       let refGen = targetEl ? () => this.putRef([targetEl], "click") : null;
       let fallback = () => this.liveSocket.redirect(window.location.href);
-      let push = this.pushWithReply(refGen, "live_patch", { url: href }, (resp) => {
+      let url = href.startsWith("/") ? `${location.protocol}//${location.host}${href}` : href;
+      let push = this.pushWithReply(refGen, "live_patch", { url }, (resp) => {
         this.liveSocket.requestDOMUpdate(() => {
           if (resp.link_redirect) {
             this.liveSocket.replaceMain(href, null, callback, linkRef);
@@ -4933,11 +5175,12 @@ within:
       let template = document.createElement("template");
       template.innerHTML = html;
       return dom_default.all(this.el, `form[${phxChange}]`).filter((form) => form.id && this.ownsElement(form)).filter((form) => form.elements.length > 0).filter((form) => form.getAttribute(this.binding(PHX_AUTO_RECOVER)) !== "ignore").map((form) => {
-        let newForm = template.content.querySelector(`form[id="${form.id}"][${phxChange}="${form.getAttribute(phxChange)}"]`);
+        const phxChangeValue = form.getAttribute(phxChange).replaceAll(/([\[\]"])/g, "\\$1");
+        let newForm = template.content.querySelector(`form[id="${form.id}"][${phxChange}="${phxChangeValue}"]`);
         if (newForm) {
           return [form, newForm, this.targetComponentID(newForm)];
         } else {
-          return [form, null, null];
+          return [form, form, this.targetComponentID(form)];
         }
       }).filter(([form, newForm, newCid]) => newForm);
     }
@@ -5099,6 +5342,11 @@ within:
     }
     execJS(el, encodedJS, eventType = null) {
       this.owner(el, (view) => js_default.exec(eventType, encodedJS, view, el));
+    }
+    execJSHookPush(el, phxEvent, data, callback) {
+      this.withinOwners(el, (view) => {
+        js_default.exec("hook", phxEvent, view, el, ["push", { data, callback }]);
+      });
     }
     unload() {
       if (this.unloaded) {
@@ -5269,7 +5517,7 @@ within:
             dom_default.findPhxSticky(document).forEach((el) => newMainEl.appendChild(el));
             this.outgoingMainEl.replaceWith(newMainEl);
             this.outgoingMainEl = null;
-            callback && requestAnimationFrame(callback);
+            callback && requestAnimationFrame(() => callback(linkRef));
             onDone();
           });
         }
@@ -5279,9 +5527,7 @@ within:
       let removeAttr = this.binding("remove");
       elements = elements || dom_default.all(document, `[${removeAttr}]`);
       elements.forEach((el) => {
-        if (document.body.contains(el)) {
-          this.execJS(el, el.getAttribute(removeAttr), "remove");
-        }
+        this.execJS(el, el.getAttribute(removeAttr), "remove");
       });
     }
     isPhxView(el) {
@@ -5368,9 +5614,6 @@ within:
       }
       this.boundTopLevelEvents = true;
       this.socket.onClose((event) => {
-        if (event && event.code === 1001) {
-          return this.unload();
-        }
         if (event && event.code === 1e3 && this.main) {
           return this.reloadWithJitter(this.main);
         }
@@ -5505,14 +5748,16 @@ within:
         }
         let phxEvent = target && target.getAttribute(click);
         if (!phxEvent) {
-          let href = e.target instanceof HTMLAnchorElement ? e.target.getAttribute("href") : null;
-          if (!capture && href !== null && !dom_default.wantsNewTab(e) && dom_default.isNewPageHref(href, window.location)) {
+          if (!capture && dom_default.isNewPageClick(e, window.location)) {
             this.unload();
           }
           return;
         }
         if (target.getAttribute("href") === "#") {
           e.preventDefault();
+        }
+        if (target.hasAttribute(PHX_REF)) {
+          return;
         }
         this.debounce(target, e, "click", () => {
           this.withinOwners(target, (view) => {
@@ -5554,6 +5799,7 @@ within:
         }
         let { type, id, root, scroll } = event.state || {};
         let href = window.location.href;
+        dom_default.dispatchEvent(window, "phx:navigate", { detail: { href, patch: type === "patch", pop: true } });
         this.requestDOMUpdate(() => {
           if (this.main.isConnected() && (type === "patch" && id === this.main.id)) {
             this.main.pushLinkPatch(href, null, () => {
@@ -5631,6 +5877,7 @@ within:
         return;
       }
       browser_default.pushState(linkState, { type: "patch", id: this.main.id }, href);
+      dom_default.dispatchEvent(window, "phx:navigate", { detail: { patch: true, href, pop: false } });
       this.registerNewLocation(window.location);
     }
     historyRedirect(href, linkState, flash) {
@@ -5643,9 +5890,12 @@ within:
       }
       let scroll = window.scrollY;
       this.withPageLoading({ to: href, kind: "redirect" }, (done) => {
-        this.replaceMain(href, flash, () => {
-          browser_default.pushState(linkState, { type: "redirect", id: this.main.id, scroll }, href);
-          this.registerNewLocation(window.location);
+        this.replaceMain(href, flash, (linkRef) => {
+          if (linkRef === this.linkRef) {
+            browser_default.pushState(linkState, { type: "redirect", id: this.main.id, scroll }, href);
+            dom_default.dispatchEvent(window, "phx:navigate", { detail: { href, patch: false, pop: false } });
+            this.registerNewLocation(window.location);
+          }
           done();
         });
       });
@@ -5713,7 +5963,7 @@ within:
           let currentIterations = iterations;
           iterations++;
           let { at, type: lastType } = dom_default.private(input, "prev-iteration") || {};
-          if (at === currentIterations - 1 && type !== lastType) {
+          if (at === currentIterations - 1 && type === "change" && lastType === "input") {
             return;
           }
           dom_default.putPrivate(input, "prev-iteration", { at: currentIterations, type });


### PR DESCRIPTION
I always like to run the following line:

`cargo clippy -- -D clippy::nursery -D clippy::all -D clippy::complexity -A clippy::use_self `

Which tends to find nice stuff, but its better to not add it too CI because some stuff is more opinionated.

- With this i found some places where one can use [fused multiply add](https://doc.rust-lang.org/std/primitive.f64.html#method.mul_add) which has less rounding errors and sometimes faster perf, i also found a method that can be const.
- Added a clippy allow because rustler generates names that don't follow conventions.
- Updated some dependencies.
- Made release use lto and minimum codegen units for maximum perfomance