### PR TITLE
Add new damage tracker list

### DIFF
--- a/native/game_backend/src/effect.rs
+++ b/native/game_backend/src/effect.rs
@@ -1,7 +1,7 @@
 use rustler::{NifMap, NifTaggedEnum};
 use serde::Deserialize;
 
-#[derive(Deserialize, NifMap, Clone)]
+#[derive(Deserialize, NifMap, Clone, Debug)]
 pub struct Effect {
     pub name: String,
     pub is_reversable: bool,
@@ -11,21 +11,21 @@ pub struct Effect {
     pub skills_keys_to_execute: Vec<String>,
 }
 
-#[derive(Deserialize, NifMap, Clone)]
+#[derive(Deserialize, NifMap, Clone, Debug)]
 pub struct AttributeChange {
     pub attribute: String, // TODO: Can this be force to be certain things? Maybe an enum
     pub modifier: AttributeModifier,
     pub value: String, // TODO: Figure out how to do dynamic types here
 }
 
-#[derive(Deserialize, NifTaggedEnum, Clone)]
+#[derive(Deserialize, NifTaggedEnum, Clone, Debug)]
 pub enum AttributeModifier {
     Additive,
     Multiplicative,
     Override,
 }
 
-#[derive(Deserialize, NifTaggedEnum, Clone, PartialEq)]
+#[derive(Deserialize, NifTaggedEnum, Clone, PartialEq, Debug)]
 pub enum TimeType {
     Instant,
     Permanent,

--- a/native/game_backend/src/effect.rs
+++ b/native/game_backend/src/effect.rs
@@ -1,7 +1,7 @@
 use rustler::{NifMap, NifTaggedEnum};
 use serde::Deserialize;
 
-#[derive(Deserialize, NifMap, Clone, Debug)]
+#[derive(Deserialize, NifMap, Clone)]
 pub struct Effect {
     pub name: String,
     pub is_reversable: bool,
@@ -11,21 +11,21 @@ pub struct Effect {
     pub skills_keys_to_execute: Vec<String>,
 }
 
-#[derive(Deserialize, NifMap, Clone, Debug)]
+#[derive(Deserialize, NifMap, Clone)]
 pub struct AttributeChange {
     pub attribute: String, // TODO: Can this be force to be certain things? Maybe an enum
     pub modifier: AttributeModifier,
     pub value: String, // TODO: Figure out how to do dynamic types here
 }
 
-#[derive(Deserialize, NifTaggedEnum, Clone, Debug)]
+#[derive(Deserialize, NifTaggedEnum, Clone)]
 pub enum AttributeModifier {
     Additive,
     Multiplicative,
     Override,
 }
 
-#[derive(Deserialize, NifTaggedEnum, Clone, PartialEq, Eq, Debug)]
+#[derive(Deserialize, NifTaggedEnum, Clone, PartialEq, Eq)]
 pub enum TimeType {
     Instant,
     Permanent,

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -93,7 +93,7 @@ pub struct KillEvent {
     pub kill_by: EntityOwner,
     pub killed: u64,
 }
-#[derive(Clone, NifTuple, Debug)]
+#[derive(Clone, NifTuple)]
 pub struct DamageTracker {
     pub damage: i64,
     pub attacker: EntityOwner,

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -410,10 +410,7 @@ fn apply_damages_and_effects(
         if let Some(victim) = players.get_mut(&damage_tracker.attacked_id) {
             if victim.status != PlayerStatus::Death {
                 victim.decrease_health(damage_tracker.damage.abs() as u64);
-                victim.apply_effects(
-                    &damage_tracker.on_hit_effects,
-                    damage_tracker.attacker,
-                );
+                victim.apply_effects(&damage_tracker.on_hit_effects, damage_tracker.attacker);
                 if victim.status == PlayerStatus::Death {
                     next_killfeed.push(KillEvent {
                         kill_by: damage_tracker.attacker,

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -409,7 +409,7 @@ fn apply_damages_and_effects(
     while let Some(damage_tracker) = pending_damages.pop() {
         if let Some(victim) = players.get_mut(&damage_tracker.attacked_id) {
             if victim.status != PlayerStatus::Death {
-                victim.decrease_health(damage_tracker.damage.abs() as u64);
+                victim.decrease_health(damage_tracker.damage.unsigned_abs());
                 victim.apply_effects(&damage_tracker.on_hit_effects, damage_tracker.attacker);
                 if victim.status == PlayerStatus::Death {
                     next_killfeed.push(KillEvent {

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -95,7 +95,7 @@ pub struct KillEvent {
 }
 #[derive(Clone, NifTuple, Debug)]
 pub struct DamageTracker {
-    pub damage: u64,
+    pub damage: i64,
     pub attacker: EntityOwner,
     pub attacked_id: u64,
     pub on_hit_effects: Vec<Effect>,
@@ -355,7 +355,7 @@ impl GameState {
                                     self.pending_damages.push(DamageTracker {
                                         attacked_id: target_player.id,
                                         attacker: EntityOwner::Player(player.id),
-                                        damage: damage,
+                                        damage: damage as i64,
                                         on_hit_effects: on_hit_effects.clone(),
                                     });
                                 })
@@ -409,7 +409,7 @@ fn apply_damages_and_effects(
     while let Some(damage_tracker) = pending_damages.pop() {
         if let Some(victim) = players.get_mut(&damage_tracker.attacked_id) {
             if victim.status != PlayerStatus::Death {
-                victim.decrease_health(damage_tracker.damage);
+                victim.decrease_health(damage_tracker.damage.abs() as u64);
                 victim.apply_effects(
                     &damage_tracker.on_hit_effects,
                     damage_tracker.attacker,
@@ -562,7 +562,7 @@ fn apply_projectiles_collisions(
                 pending_damages.push(DamageTracker {
                     attacked_id: player.id,
                     attacker: EntityOwner::Player(projectile.player_id),
-                    damage: projectile.damage,
+                    damage: projectile.damage as i64,
                     on_hit_effects: projectile.on_hit_effects.clone(),
                 });
 

--- a/native/game_backend/src/player.rs
+++ b/native/game_backend/src/player.rs
@@ -169,7 +169,6 @@ impl Player {
                                 modify_attribute(&mut player.size, &change.modifier, &change.value)
                             }
                             "health" => {
-                                println!("apply");
                                 modify_attribute(
                                     &mut player.health,
                                     &change.modifier,

--- a/native/game_backend/src/player.rs
+++ b/native/game_backend/src/player.rs
@@ -288,14 +288,12 @@ impl Player {
                         effect.player_attributes.iter().for_each(|change| {
                             match change.attribute.as_str() {
                                 "health" => {
-                                    damages.push(
-                                        DamageTracker{
-                                            damage: change.value.parse::<u64>().unwrap(),
-                                            attacker: owner.clone(),
-                                            attacked_id: self.id,
-                                            on_hit_effects: vec![]
-                                        }
-                                    );
+                                    damages.push(DamageTracker {
+                                        damage: change.value.parse::<u64>().unwrap(),
+                                        attacker: owner.clone(),
+                                        attacked_id: self.id,
+                                        on_hit_effects: vec![],
+                                    });
                                 }
 
                                 _ => todo!(),

--- a/native/game_backend/src/player.rs
+++ b/native/game_backend/src/player.rs
@@ -169,6 +169,7 @@ impl Player {
                                 modify_attribute(&mut player.size, &change.modifier, &change.value)
                             }
                             "health" => {
+                                println!("apply");
                                 modify_attribute(
                                     &mut player.health,
                                     &change.modifier,
@@ -289,8 +290,8 @@ impl Player {
                             match change.attribute.as_str() {
                                 "health" => {
                                     damages.push(DamageTracker {
-                                        damage: change.value.parse::<u64>().unwrap(),
-                                        attacker: owner.clone(),
+                                        damage: change.value.parse::<i64>().unwrap(),
+                                        attacker: *owner,
                                         attacked_id: self.id,
                                         on_hit_effects: vec![],
                                     });


### PR DESCRIPTION
We were having some borrowing issues with the damage application and the player list, so we'll split the damage on 2 steps

1. If a player is victim of a damaging effect (can be an effect or a hit) we'll store this in a list called `pending_damages` 
2. Every tick we traverse this list and apply the pending damages poping them outside of the list, we also apply the on hit effect here

To test this pr you should test it with a client in the main branch and check that the damage applications feels right