### PR TITLE
Modify position representations from integers to floats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,12 @@
 members = [
     "native/game_backend",
 ]
+
+## to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
+## some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
+resolver = "2"
+
+## profiles for the non root package will be ignored, specify profiles at the workspace root
+[profile.release]
+lto = true
+codegen-units = 1

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -345,9 +345,7 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
     y_distance = abs(end_y - start_y)
     remaining = abs(x_distance - y_distance)
 
-    (diagonal_movement_cost * Enum.min([x_distance, y_distance]) +
-       remaining * straight_movement_cost)
-    |> div(10)
+    (diagonal_movement_cost * Enum.min([x_distance, y_distance]) + remaining * straight_movement_cost) / 10
   end
 
   defp map_entities(entities, bot, type) do
@@ -432,8 +430,8 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
       ])
 
     wandering_position = %{
-      x: Enum.random(left_x..right_x),
-      y: Enum.random(down_y..up_y)
+      x: Enum.random(trunc(left_x)..trunc(right_x)),
+      y: Enum.random(trunc(down_y)..trunc(up_y))
     }
 
     Map.merge(bot_state, %{current_wandering_position: wandering_position, objective: :wander})

--- a/lib/dark_worlds_server/communication/messages.pb.ex
+++ b/lib/dark_worlds_server/communication/messages.pb.ex
@@ -284,7 +284,7 @@ defmodule DarkWorldsServer.Communication.Proto.Player do
   field(:id, 1, type: :uint64)
   field(:position, 2, type: DarkWorldsServer.Communication.Proto.Position)
   field(:health, 3, type: :sint64)
-  field(:speed, 4, type: :sint64)
+  field(:speed, 4, type: :float)
   field(:size, 5, type: :float)
   field(:direction, 6, type: :float)
   field(:status, 7, type: DarkWorldsServer.Communication.Proto.PlayerStatus, enum: true)
@@ -369,7 +369,7 @@ defmodule DarkWorldsServer.Communication.Proto.Projectile do
   field(:id, 1, type: :uint64)
   field(:name, 2, type: :string)
   field(:damage, 3, type: :uint32)
-  field(:speed, 4, type: :uint32)
+  field(:speed, 4, type: :float)
   field(:size, 5, type: :float)
   field(:position, 6, type: DarkWorldsServer.Communication.Proto.Position)
   field(:direction, 7, type: :float)
@@ -393,8 +393,8 @@ defmodule DarkWorldsServer.Communication.Proto.Position do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:x, 1, type: :int64)
-  field(:y, 2, type: :int64)
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 
   def transform_module(), do: DarkWorldsServer.Communication.ProtoTransform
 end
@@ -454,7 +454,7 @@ defmodule DarkWorldsServer.Communication.Proto.OldGameEvent do
   field(:player_timestamp, 9, type: :int64, json_name: "playerTimestamp")
   field(:server_timestamp, 10, type: :int64, json_name: "serverTimestamp")
   field(:killfeed, 11, repeated: true, type: DarkWorldsServer.Communication.Proto.OldKillEvent)
-  field(:playable_radius, 12, type: :uint64, json_name: "playableRadius")
+  field(:playable_radius, 12, type: :float, json_name: "playableRadius")
 
   field(:shrinking_center, 13,
     type: DarkWorldsServer.Communication.Proto.OldPosition,
@@ -589,8 +589,8 @@ defmodule DarkWorldsServer.Communication.Proto.OldPosition do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:x, 1, type: :uint64)
-  field(:y, 2, type: :uint64)
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 
   def transform_module(), do: DarkWorldsServer.Communication.ProtoTransform
 end
@@ -730,8 +730,8 @@ defmodule DarkWorldsServer.Communication.Proto.BoardSize do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:width, 1, type: :uint64)
-  field(:height, 2, type: :uint64)
+  field(:width, 1, type: :float)
+  field(:height, 2, type: :float)
 
   def transform_module(), do: DarkWorldsServer.Communication.ProtoTransform
 end
@@ -834,8 +834,8 @@ defmodule DarkWorldsServer.Communication.Proto.OldProjectile do
   field(:id, 1, type: :uint64)
   field(:position, 2, type: DarkWorldsServer.Communication.Proto.OldPosition)
   field(:direction, 3, type: DarkWorldsServer.Communication.Proto.RelativePosition)
-  field(:speed, 4, type: :uint32)
-  field(:range, 5, type: :uint32)
+  field(:speed, 4, type: :float)
+  field(:range, 5, type: :float)
   field(:player_id, 6, type: :uint64, json_name: "playerId")
   field(:damage, 7, type: :uint32)
   field(:remaining_ticks, 8, type: :sint64, json_name: "remainingTicks")
@@ -902,8 +902,8 @@ defmodule DarkWorldsServer.Communication.Proto.GameStateConfig do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:width, 1, type: :uint64)
-  field(:height, 2, type: :uint64)
+  field(:width, 1, type: :float)
+  field(:height, 2, type: :float)
 
   field(:map_modification, 3,
     type: DarkWorldsServer.Communication.Proto.MapModification,
@@ -921,9 +921,9 @@ defmodule DarkWorldsServer.Communication.Proto.MapModification do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:modification, 1, type: DarkWorldsServer.Communication.Proto.Modification)
-  field(:starting_radius, 2, type: :uint64, json_name: "startingRadius")
-  field(:minimum_radius, 3, type: :uint64, json_name: "minimumRadius")
-  field(:max_radius, 4, type: :uint64, json_name: "maxRadius")
+  field(:starting_radius, 2, type: :float, json_name: "startingRadius")
+  field(:minimum_radius, 3, type: :float, json_name: "minimumRadius")
+  field(:max_radius, 4, type: :float, json_name: "maxRadius")
 
   field(:outside_radius_effects, 5,
     repeated: true,
@@ -957,7 +957,7 @@ defmodule DarkWorldsServer.Communication.Proto.GameLoot do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
-  field(:size, 2, type: :uint64)
+  field(:size, 2, type: :float)
   field(:effects, 3, repeated: true, type: DarkWorldsServer.Communication.Proto.GameEffect)
 
   def transform_module(), do: DarkWorldsServer.Communication.ProtoTransform
@@ -970,8 +970,8 @@ defmodule DarkWorldsServer.Communication.Proto.GameProjectile do
 
   field(:name, 1, type: :string)
   field(:base_damage, 2, type: :uint64, json_name: "baseDamage")
-  field(:base_speed, 3, type: :uint64, json_name: "baseSpeed")
-  field(:base_size, 4, type: :uint64, json_name: "baseSize")
+  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
+  field(:base_size, 4, type: :float, json_name: "baseSize")
   field(:remove_on_collision, 5, type: :bool, json_name: "removeOnCollision")
 
   field(:on_hit_effect, 6,
@@ -980,7 +980,7 @@ defmodule DarkWorldsServer.Communication.Proto.GameProjectile do
     json_name: "onHitEffect"
   )
 
-  field(:max_distance, 7, type: :uint64, json_name: "maxDistance")
+  field(:max_distance, 7, type: :float, json_name: "maxDistance")
   field(:duration_ms, 8, type: :float, json_name: "durationMs")
 
   def transform_module(), do: DarkWorldsServer.Communication.ProtoTransform
@@ -1004,8 +1004,8 @@ defmodule DarkWorldsServer.Communication.Proto.GameCharacter do
 
   field(:name, 1, type: :string)
   field(:active, 2, type: :bool)
-  field(:base_speed, 3, type: :uint64, json_name: "baseSpeed")
-  field(:base_size, 4, type: :uint64, json_name: "baseSize")
+  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
+  field(:base_size, 4, type: :float, json_name: "baseSize")
   field(:base_health, 5, type: :uint64, json_name: "baseHealth")
 
   field(:skills, 6,
@@ -1038,7 +1038,7 @@ defmodule DarkWorldsServer.Communication.Proto.Mechanic do
   field(:name, 1, type: DarkWorldsServer.Communication.Proto.MechanicType, enum: true)
   field(:effects, 2, repeated: true, type: DarkWorldsServer.Communication.Proto.GameEffect)
   field(:damage, 3, type: :uint64)
-  field(:range, 4, type: :uint64)
+  field(:range, 4, type: :float)
   field(:cone_angle, 5, type: :uint64, json_name: "coneAngle")
 
   field(:on_hit_effects, 6,
@@ -1050,7 +1050,7 @@ defmodule DarkWorldsServer.Communication.Proto.Mechanic do
   field(:projectile, 7, type: DarkWorldsServer.Communication.Proto.GameProjectile)
   field(:count, 8, type: :uint64)
   field(:duration_ms, 9, type: :uint64, json_name: "durationMs")
-  field(:max_range, 10, type: :uint64, json_name: "maxRange")
+  field(:max_range, 10, type: :float, json_name: "maxRange")
 
   def transform_module(), do: DarkWorldsServer.Communication.ProtoTransform
 end
@@ -1122,6 +1122,8 @@ defmodule DarkWorldsServer.Communication.Proto.UseSkill do
   field(:skill, 1, type: :string)
   field(:angle, 2, type: :float)
   field(:auto_aim, 3, type: :bool, json_name: "autoAim")
+  field(:target_x, 4, type: :float, json_name: "targetX")
+  field(:target_y, 5, type: :float, json_name: "targetY")
 
   def transform_module(), do: DarkWorldsServer.Communication.ProtoTransform
 end

--- a/lib/dark_worlds_server/config/characters/character.ex
+++ b/lib/dark_worlds_server/config/characters/character.ex
@@ -14,8 +14,8 @@ defmodule DarkWorldsServer.Config.Characters.Character do
   schema "characters" do
     field(:active, :boolean, default: false)
     field(:name, :string)
-    field(:base_speed, :integer)
-    field(:base_size, :integer)
+    field(:base_speed, :float)
+    field(:base_size, :float)
     field(:base_health, :integer)
     field(:max_inventory_size, :integer)
 

--- a/lib/dark_worlds_server/config/characters/projectile.ex
+++ b/lib/dark_worlds_server/config/characters/projectile.ex
@@ -13,10 +13,10 @@ defmodule DarkWorldsServer.Config.Characters.Projectile do
   schema "projectiles" do
     field(:name, :string)
     field(:base_damage, :integer)
-    field(:base_speed, :integer)
-    field(:base_size, :integer)
+    field(:base_speed, :float)
+    field(:base_size, :float)
     field(:duration_ms, :integer)
-    field(:max_distance, :integer)
+    field(:max_distance, :float)
     field(:remove_on_collision, :boolean)
 
     many_to_many(:on_hit_effects, Effect, join_through: ProjectileEffect)

--- a/lib/dark_worlds_server/config/characters/skill_mechanic.ex
+++ b/lib/dark_worlds_server/config/characters/skill_mechanic.ex
@@ -61,7 +61,7 @@ defmodule DarkWorldsServer.Config.Characters.SkillMechanic do
         {:hit,
          %{
            damage: String.to_integer(damage),
-           range: String.to_integer(range),
+           range: String.to_float(range),
            cone_angle: String.to_integer(cone_angle),
            on_hit_effects: parse_on_hit_effects(on_hit_effects)
          }}
@@ -78,7 +78,7 @@ defmodule DarkWorldsServer.Config.Characters.SkillMechanic do
         {:simple_shoot, %{projectile: Characters.get_projectile_by_name(projectile)}}
 
       ["MoveToTarget", duration_ms, max_range] ->
-        {:move_to_target, %{duration_ms: String.to_integer(duration_ms), max_range: String.to_integer(max_range)}}
+        {:move_to_target, %{duration_ms: String.to_integer(duration_ms), max_range: String.to_float(max_range)}}
 
       _ ->
         "Invalid"

--- a/lib/dark_worlds_server/config/games/game.ex
+++ b/lib/dark_worlds_server/config/games/game.ex
@@ -9,10 +9,10 @@ defmodule DarkWorldsServer.Config.Games.Game do
 
   @primary_key {:id, :binary_id, autogenerate: true}
   schema "games" do
-    field(:width, :integer)
-    field(:height, :integer)
+    field(:width, :float)
+    field(:height, :float)
     field(:loot_interval_ms, :integer)
-    field(:zone_starting_radius, :integer)
+    field(:zone_starting_radius, :float)
     field(:auto_aim_max_distance, :float)
     field(:initial_positions, {:array, :map})
 

--- a/lib/dark_worlds_server/config/games/loot.ex
+++ b/lib/dark_worlds_server/config/games/loot.ex
@@ -13,7 +13,7 @@ defmodule DarkWorldsServer.Config.Games.Loot do
   @primary_key {:id, :binary_id, autogenerate: true}
   schema "loots" do
     field(:name, :string)
-    field(:size, :integer)
+    field(:size, :float)
     field(:pickup_mechanic, :string)
 
     many_to_many(:effects, Effect, join_through: LootEffect)

--- a/lib/dark_worlds_server/config/games/zone_modification.ex
+++ b/lib/dark_worlds_server/config/games/zone_modification.ex
@@ -14,8 +14,8 @@ defmodule DarkWorldsServer.Config.Games.ZoneModification do
   schema "zone_modifications" do
     field(:duration_ms, :integer)
     field(:interval_ms, :integer)
-    field(:min_radius, :integer)
-    field(:max_radius, :integer)
+    field(:min_radius, :float)
+    field(:max_radius, :float)
     field(:modifier, :string)
     field(:value, :float)
 

--- a/lib/dark_worlds_server/runner_supervisor/runner.ex
+++ b/lib/dark_worlds_server/runner_supervisor/runner.ex
@@ -410,8 +410,8 @@ defmodule DarkWorldsServer.RunnerSupervisor.Runner do
     {width, height} = Process.get(:map_size)
 
     %GameBackend.Position{
-      x: -1 * position.y + div(width, 2),
-      y: position.x + div(height, 2)
+      x: -1 * position.y + width / 2,
+      y: position.x + height / 2
     }
   end
 

--- a/load_test/lib/load_test/communication/messages.pb.ex
+++ b/load_test/lib/load_test/communication/messages.pb.ex
@@ -274,7 +274,7 @@ defmodule LoadTest.Communication.Proto.Player do
   field(:id, 1, type: :uint64)
   field(:position, 2, type: LoadTest.Communication.Proto.Position)
   field(:health, 3, type: :sint64)
-  field(:speed, 4, type: :sint64)
+  field(:speed, 4, type: :float)
   field(:size, 5, type: :float)
   field(:direction, 6, type: :float)
   field(:status, 7, type: LoadTest.Communication.Proto.PlayerStatus, enum: true)
@@ -347,7 +347,7 @@ defmodule LoadTest.Communication.Proto.Projectile do
   field(:id, 1, type: :uint64)
   field(:name, 2, type: :string)
   field(:damage, 3, type: :uint32)
-  field(:speed, 4, type: :uint32)
+  field(:speed, 4, type: :float)
   field(:size, 5, type: :float)
   field(:position, 6, type: LoadTest.Communication.Proto.Position)
   field(:direction, 7, type: :float)
@@ -367,8 +367,8 @@ defmodule LoadTest.Communication.Proto.Position do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:x, 1, type: :int64)
-  field(:y, 2, type: :int64)
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule LoadTest.Communication.Proto.KillEvent do
@@ -422,7 +422,7 @@ defmodule LoadTest.Communication.Proto.OldGameEvent do
   field(:player_timestamp, 9, type: :int64, json_name: "playerTimestamp")
   field(:server_timestamp, 10, type: :int64, json_name: "serverTimestamp")
   field(:killfeed, 11, repeated: true, type: LoadTest.Communication.Proto.OldKillEvent)
-  field(:playable_radius, 12, type: :uint64, json_name: "playableRadius")
+  field(:playable_radius, 12, type: :float, json_name: "playableRadius")
 
   field(:shrinking_center, 13,
     type: LoadTest.Communication.Proto.OldPosition,
@@ -543,8 +543,8 @@ defmodule LoadTest.Communication.Proto.OldPosition do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:x, 1, type: :uint64)
-  field(:y, 2, type: :uint64)
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule LoadTest.Communication.Proto.RelativePosition do
@@ -662,8 +662,8 @@ defmodule LoadTest.Communication.Proto.BoardSize do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:width, 1, type: :uint64)
-  field(:height, 2, type: :uint64)
+  field(:width, 1, type: :float)
+  field(:height, 2, type: :float)
 end
 
 defmodule LoadTest.Communication.Proto.CharacterConfigItem do
@@ -754,8 +754,8 @@ defmodule LoadTest.Communication.Proto.OldProjectile do
   field(:id, 1, type: :uint64)
   field(:position, 2, type: LoadTest.Communication.Proto.OldPosition)
   field(:direction, 3, type: LoadTest.Communication.Proto.RelativePosition)
-  field(:speed, 4, type: :uint32)
-  field(:range, 5, type: :uint32)
+  field(:speed, 4, type: :float)
+  field(:range, 5, type: :float)
   field(:player_id, 6, type: :uint64, json_name: "playerId")
   field(:damage, 7, type: :uint32)
   field(:remaining_ticks, 8, type: :sint64, json_name: "remainingTicks")
@@ -814,8 +814,8 @@ defmodule LoadTest.Communication.Proto.GameStateConfig do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:width, 1, type: :uint64)
-  field(:height, 2, type: :uint64)
+  field(:width, 1, type: :float)
+  field(:height, 2, type: :float)
 
   field(:map_modification, 3,
     type: LoadTest.Communication.Proto.MapModification,
@@ -831,9 +831,9 @@ defmodule LoadTest.Communication.Proto.MapModification do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:modification, 1, type: LoadTest.Communication.Proto.Modification)
-  field(:starting_radius, 2, type: :uint64, json_name: "startingRadius")
-  field(:minimum_radius, 3, type: :uint64, json_name: "minimumRadius")
-  field(:max_radius, 4, type: :uint64, json_name: "maxRadius")
+  field(:starting_radius, 2, type: :float, json_name: "startingRadius")
+  field(:minimum_radius, 3, type: :float, json_name: "minimumRadius")
+  field(:max_radius, 4, type: :float, json_name: "maxRadius")
 
   field(:outside_radius_effects, 5,
     repeated: true,
@@ -863,7 +863,7 @@ defmodule LoadTest.Communication.Proto.GameLoot do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
-  field(:size, 2, type: :uint64)
+  field(:size, 2, type: :float)
   field(:effects, 3, repeated: true, type: LoadTest.Communication.Proto.GameEffect)
 end
 
@@ -874,8 +874,8 @@ defmodule LoadTest.Communication.Proto.GameProjectile do
 
   field(:name, 1, type: :string)
   field(:base_damage, 2, type: :uint64, json_name: "baseDamage")
-  field(:base_speed, 3, type: :uint64, json_name: "baseSpeed")
-  field(:base_size, 4, type: :uint64, json_name: "baseSize")
+  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
+  field(:base_size, 4, type: :float, json_name: "baseSize")
   field(:remove_on_collision, 5, type: :bool, json_name: "removeOnCollision")
 
   field(:on_hit_effect, 6,
@@ -884,7 +884,7 @@ defmodule LoadTest.Communication.Proto.GameProjectile do
     json_name: "onHitEffect"
   )
 
-  field(:max_distance, 7, type: :uint64, json_name: "maxDistance")
+  field(:max_distance, 7, type: :float, json_name: "maxDistance")
   field(:duration_ms, 8, type: :float, json_name: "durationMs")
 end
 
@@ -904,8 +904,8 @@ defmodule LoadTest.Communication.Proto.GameCharacter do
 
   field(:name, 1, type: :string)
   field(:active, 2, type: :bool)
-  field(:base_speed, 3, type: :uint64, json_name: "baseSpeed")
-  field(:base_size, 4, type: :uint64, json_name: "baseSize")
+  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
+  field(:base_size, 4, type: :float, json_name: "baseSize")
   field(:base_health, 5, type: :uint64, json_name: "baseHealth")
 
   field(:skills, 6,
@@ -934,7 +934,7 @@ defmodule LoadTest.Communication.Proto.Mechanic do
   field(:name, 1, type: LoadTest.Communication.Proto.MechanicType, enum: true)
   field(:effects, 2, repeated: true, type: LoadTest.Communication.Proto.GameEffect)
   field(:damage, 3, type: :uint64)
-  field(:range, 4, type: :uint64)
+  field(:range, 4, type: :float)
   field(:cone_angle, 5, type: :uint64, json_name: "coneAngle")
 
   field(:on_hit_effects, 6,
@@ -946,7 +946,7 @@ defmodule LoadTest.Communication.Proto.Mechanic do
   field(:projectile, 7, type: LoadTest.Communication.Proto.GameProjectile)
   field(:count, 8, type: :uint64)
   field(:duration_ms, 9, type: :uint64, json_name: "durationMs")
-  field(:max_range, 10, type: :uint64, json_name: "maxRange")
+  field(:max_range, 10, type: :float, json_name: "maxRange")
 end
 
 defmodule LoadTest.Communication.Proto.GameEffect.Duration do
@@ -1008,6 +1008,8 @@ defmodule LoadTest.Communication.Proto.UseSkill do
   field(:skill, 1, type: :string)
   field(:angle, 2, type: :float)
   field(:auto_aim, 3, type: :bool, json_name: "autoAim")
+  field(:target_x, 4, type: :float, json_name: "targetX")
+  field(:target_y, 5, type: :float, json_name: "targetY")
 end
 
 defmodule LoadTest.Communication.Proto.GameAction do

--- a/messages.proto
+++ b/messages.proto
@@ -38,7 +38,7 @@ message Player {
     uint64 id = 1;
     Position position = 2;
     sint64 health = 3;
-    sint64 speed = 4;
+    float speed = 4;
     float size = 5;
     float direction = 6;
     PlayerStatus status = 7;
@@ -84,7 +84,7 @@ message Projectile {
     uint64 id = 1;
     string name = 2;
     uint32 damage = 3;
-    uint32 speed = 4;
+    float speed = 4;
     float size = 5;
     Position position = 6;
     float direction = 7;
@@ -96,8 +96,8 @@ message ZoneInfo {
 }
 
 message Position {
-    int64 x = 1;
-    int64 y = 2;
+    float x = 1;
+    float y = 2;
 }
 
 message KillEvent {
@@ -156,7 +156,7 @@ message OldGameEvent {
     int64 player_timestamp = 9;
     int64 server_timestamp = 10;
     repeated OldKillEvent killfeed = 11;
-    uint64 playable_radius = 12;
+    float playable_radius = 12;
     OldPosition shrinking_center = 13;
     repeated LootPackage loots = 14;
 }
@@ -239,8 +239,8 @@ enum OldStatus {
     - y: Y coordinate in the grid
  */
 message OldPosition {
-    uint64 x = 1;
-    uint64 y = 2;
+    float x = 1;
+    float y = 2;
 }
 
 /* A relative position
@@ -410,8 +410,8 @@ message GameConfig {
 }
 
 message BoardSize {
-    uint64 width = 1;
-    uint64 height = 2;
+    float width = 1;
+    float height = 2;
 }
 
 message CharacterConfigItem {
@@ -510,8 +510,8 @@ message OldProjectile {
     uint64 id = 1;
     OldPosition position = 2;
     RelativePosition direction = 3;
-    uint32 speed = 4;
-    uint32 range = 5;
+    float speed = 4;
+    float range = 5;
     uint64 player_id = 6;
     uint32 damage = 7;
     sint64 remaining_ticks = 8;
@@ -588,8 +588,8 @@ message Config {
     - loot_interval_ms: If present, interval in milliseconds for spawning loot crates
 */
 message GameStateConfig {
-    uint64 width = 1;
-    uint64 height = 2;
+    float width = 1;
+    float height = 2;
     MapModification map_modification = 3;
     uint64 loot_interval_ms = 4;
 }
@@ -604,9 +604,9 @@ message GameStateConfig {
 */
 message MapModification {
     Modification modification = 1;
-    uint64 starting_radius = 2;
-    uint64 minimum_radius = 3;
-    uint64 max_radius = 4;
+    float starting_radius = 2;
+    float minimum_radius = 3;
+    float max_radius = 4;
     repeated GameEffect outside_radius_effects = 5;
     repeated GameEffect inside_radius_effects = 6;
 }
@@ -630,7 +630,7 @@ message Modification {
 */
 message GameLoot {
     string name = 1;
-    uint64 size = 2;
+    float size = 2;
     repeated GameEffect effects = 3;
 }
 
@@ -647,11 +647,11 @@ message GameLoot {
 message GameProjectile {
     string name = 1;
     uint64 base_damage = 2;
-    uint64 base_speed = 3;
-    uint64 base_size = 4;
+    float base_speed = 3;
+    float base_size = 4;
     bool remove_on_collision = 5;
     repeated GameEffect on_hit_effect = 6;
-    uint64 max_distance = 7;
+    float max_distance = 7;
     float duration_ms = 8;
 }
 
@@ -666,8 +666,8 @@ message GameProjectile {
 message GameCharacter {
     string name = 1;
     bool active = 2;
-    uint64 base_speed = 3;
-    uint64 base_size = 4;
+    float base_speed = 3;
+    float base_size = 4;
     uint64 base_health = 5;
     map<string, GameSkill> skills = 6;
 }
@@ -707,13 +707,13 @@ message Mechanic {
     MechanicType name = 1;
     repeated GameEffect effects = 2;
     uint64 damage = 3;
-    uint64 range = 4;
+    float range = 4;
     uint64 cone_angle = 5;
     repeated GameEffect on_hit_effects = 6;
     GameProjectile projectile = 7;
     uint64 count = 8;
     uint64 duration_ms = 9;
-    uint64 max_range = 10;
+    float max_range = 10;
 }
 
 /* Represents an effect acting on a player.
@@ -765,6 +765,8 @@ message UseSkill {
   string skill = 1;
   float angle = 2;
   bool auto_aim = 3;
+  float target_x = 4;
+  float target_y = 5;
 }
 
 message GameAction {

--- a/native/game_backend/src/character.rs
+++ b/native/game_backend/src/character.rs
@@ -9,8 +9,8 @@ use crate::skill::SkillConfig;
 pub struct CharacterConfigFile {
     name: String,
     active: bool,
-    base_speed: u64,
-    base_size: u64,
+    base_speed: f32,
+    base_size: f32,
     base_health: u64,
     max_inventory_size: u64,
     skills: HashMap<String, String>,
@@ -20,8 +20,8 @@ pub struct CharacterConfigFile {
 pub struct CharacterConfig {
     pub name: String,
     pub active: bool,
-    pub base_speed: u64,
-    pub base_size: u64,
+    pub base_speed: f32,
+    pub base_size: f32,
     pub base_health: u64,
     pub max_inventory_size: u64,
     pub skills: HashMap<String, SkillConfig>,

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -32,10 +32,10 @@ pub enum EntityOwner {
 
 #[derive(Deserialize)]
 pub struct GameConfigFile {
-    width: u64,
-    height: u64,
+    width: f32,
+    height: f32,
     loot_interval_ms: u64,
-    zone_starting_radius: u64,
+    zone_starting_radius: f32,
     zone_modifications: Vec<ZoneModificationConfigFile>,
     auto_aim_max_distance: f32,
     initial_positions: Vec<Position>,
@@ -45,18 +45,18 @@ pub struct GameConfigFile {
 pub struct ZoneModificationConfigFile {
     duration_ms: u64,
     interval_ms: u64,
-    min_radius: u64,
-    max_radius: u64,
+    min_radius: f32,
+    max_radius: f32,
     outside_radius_effects: Vec<String>,
     modification: ZoneModificationModifier,
 }
 
 #[derive(NifMap)]
 pub struct GameConfig {
-    pub width: u64,
-    pub height: u64,
+    pub width: f32,
+    pub height: f32,
     pub loot_interval_ms: u64,
-    pub zone_starting_radius: u64,
+    pub zone_starting_radius: f32,
     pub zone_modifications: Vec<ZoneModificationConfig>,
     pub auto_aim_max_distance: f32,
     pub initial_positions: Vec<Position>,
@@ -66,8 +66,8 @@ pub struct GameConfig {
 pub struct ZoneModificationConfig {
     duration_ms: u64,
     interval_ms: u64,
-    min_radius: u64,
-    max_radius: u64,
+    min_radius: f32,
+    max_radius: f32,
     outside_radius_effects: Vec<Effect>,
     modification: ZoneModificationModifier,
 }
@@ -76,13 +76,13 @@ pub struct ZoneModificationConfig {
 #[serde(tag = "modifier", content = "value")]
 pub enum ZoneModificationModifier {
     Additive(i64),
-    Multiplicative(f64),
+    Multiplicative(f32),
 }
 
 #[derive(NifMap)]
 pub struct Zone {
     pub center: Position,
-    pub radius: u64,
+    pub radius: f32,
     pub current_modification: Option<ZoneModificationConfig>,
     pub modifications: Vec<ZoneModificationConfig>,
     pub time_since_last_modification_ms: u64,
@@ -515,7 +515,7 @@ fn move_projectiles(projectiles: &mut Vec<Projectile>, time_diff: u64, config: &
     projectiles.retain(|projectile| {
         projectile.active
             && projectile.duration_ms > 0
-            && projectile.max_distance > 0
+            && projectile.max_distance > 0.0
             && !map::collision_with_edge(
                 &projectile.position,
                 projectile.size,
@@ -526,12 +526,12 @@ fn move_projectiles(projectiles: &mut Vec<Projectile>, time_diff: u64, config: &
 
     projectiles.iter_mut().for_each(|projectile| {
         projectile.duration_ms = projectile.duration_ms.saturating_sub(time_diff);
-        projectile.max_distance = projectile.max_distance.saturating_sub(projectile.speed);
+        projectile.max_distance -= projectile.speed;
         projectile.position = map::next_position(
             &projectile.position,
             projectile.direction_angle,
-            projectile.speed as f32,
-            config.game.width as f32,
+            projectile.speed,
+            config.game.width,
         )
     });
 }
@@ -601,12 +601,8 @@ fn modify_zone(zone: &mut Zone, time_diff: u64) {
                 zone.time_since_last_modification_ms -= zone_modification.interval_ms;
 
                 let new_radius = match zone_modification.modification {
-                    ZoneModificationModifier::Additive(value) => {
-                        zone.radius.saturating_add_signed(value)
-                    }
-                    ZoneModificationModifier::Multiplicative(value) => {
-                        ((zone.radius as f64) * value) as u64
-                    }
+                    ZoneModificationModifier::Additive(value) => zone.radius + (value as f32),
+                    ZoneModificationModifier::Multiplicative(value) => zone.radius * value,
                 };
 
                 zone.radius =
@@ -637,7 +633,7 @@ fn apply_zone_effects(
             // We set size of player as 0 so a player has to be half way inside the zone to be considered inside
             // otherwise if just a border of the player where inside it would be considered inside which seems wrong
             .partition(|player| {
-                map::hit_boxes_collide(&zone.center, &player.position, zone.radius, 0)
+                map::hit_boxes_collide(&zone.center, &player.position, zone.radius, 0.0)
             });
 
         inside_players.into_iter().for_each(|player| {

--- a/native/game_backend/src/lib.rs
+++ b/native/game_backend/src/lib.rs
@@ -39,7 +39,7 @@ fn add_player(
         Some(character_config) => {
             let rng = &mut rand::thread_rng();
             let initial_position = if game.config.game.initial_positions.is_empty() {
-                Position { x: 0, y: 0 }
+                Position { x: 0.0, y: 0.0 }
             } else {
                 game.config
                     .game

--- a/native/game_backend/src/loot.rs
+++ b/native/game_backend/src/loot.rs
@@ -9,7 +9,7 @@ use crate::map::{self, Position};
 #[derive(Deserialize, NifMap)]
 pub struct LootFileConfig {
     name: String,
-    size: u64,
+    size: f32,
     pickup_mechanic: PickupMechanic,
     effects: Vec<String>,
 }
@@ -17,7 +17,7 @@ pub struct LootFileConfig {
 #[derive(NifMap)]
 pub struct LootConfig {
     name: String,
-    size: u64,
+    size: f32,
     pickup_mechanic: PickupMechanic,
     effects: Vec<Effect>,
 }
@@ -25,7 +25,7 @@ pub struct LootConfig {
 #[derive(NifMap, Clone)]
 pub struct Loot {
     pub name: String,
-    pub size: u64,
+    pub size: f32,
     pub pickup_mechanic: PickupMechanic,
     pub effects: Vec<Effect>,
     pub id: u64,

--- a/native/game_backend/src/map.rs
+++ b/native/game_backend/src/map.rs
@@ -8,13 +8,13 @@ use crate::player::Player;
 
 #[derive(NifMap, Clone, Deserialize, Copy)]
 pub struct Position {
-    pub x: i64,
-    pub y: i64,
+    pub x: f32,
+    pub y: f32,
 }
 
-pub fn hit_boxes_collide(center1: &Position, center2: &Position, size1: u64, size2: u64) -> bool {
-    let squared_x = (center1.x - center2.x).pow(2) as f64;
-    let squared_y = (center1.y - center2.y).pow(2) as f64;
+pub fn hit_boxes_collide(center1: &Position, center2: &Position, size1: f32, size2: f32) -> bool {
+    let squared_x = (center1.x - center2.x).powi(2) as f64;
+    let squared_y = (center1.y - center2.y).powi(2) as f64;
     let centers_distance = (squared_x + squared_y).sqrt();
     let collision_distance = (size1 + size2) as f64;
     centers_distance <= collision_distance
@@ -23,22 +23,22 @@ pub fn hit_boxes_collide(center1: &Position, center2: &Position, size1: u64, siz
 pub fn in_cone_angle_range(
     center_player: &Player,
     target_player: &Player,
-    max_distance: u64,
+    max_distance: f32,
     cone_angle: f32,
 ) -> bool {
     // TODO: Take into consideration `size` attribute of Player
-    let squared_x = (center_player.position.x - target_player.position.x).pow(2) as f64;
-    let squared_y = (center_player.position.y - target_player.position.y).pow(2) as f64;
+    let squared_x = (center_player.position.x - target_player.position.x).powi(2) as f64;
+    let squared_y = (center_player.position.y - target_player.position.y).powi(2) as f64;
     let target_distance = (squared_x + squared_y).sqrt();
 
     if target_distance > (max_distance as f64) {
         return false;
-    } else if target_distance <= ((center_player.size * 3) as f64) {
+    } else if target_distance <= ((center_player.size * 3.0) as f64) {
         return true;
     }
 
-    let x_diff = (target_player.position.x - center_player.position.x) as f32;
-    let y_diff = (target_player.position.y - center_player.position.y) as f32;
+    let x_diff = target_player.position.x - center_player.position.x;
+    let y_diff = target_player.position.y - center_player.position.y;
     let angle = y_diff.atan2(x_diff) * (180.0 / PI);
     let relative_angle = angle - center_player.direction;
     let normalized_angle = (relative_angle + 360.0) % 360.0;
@@ -53,18 +53,15 @@ pub fn next_position(
     width: f32,
 ) -> Position {
     let angle_rad = direction_angle * (PI / 180.0);
-    let new_x = movement_amount.mul_add(angle_rad.cos(), current_position.x as f32);
-    let new_y = movement_amount.mul_add(angle_rad.sin(), current_position.y as f32);
+    let new_x = movement_amount.mul_add(angle_rad.cos(), current_position.x);
+    let new_y = movement_amount.mul_add(angle_rad.sin(), current_position.y);
 
     // This is to avoid  the overflow on the front end
     let radius = (width - 200.0) / 2.0;
 
-    let center = Position { x: 0, y: 0 };
+    let center = Position { x: 0.0, y: 0.0 };
 
-    let new_position = Position {
-        x: new_x as i64,
-        y: new_y as i64,
-    };
+    let new_position = Position { x: new_x, y: new_y };
 
     if distance_between_positions(&new_position, &center) <= radius {
         new_position
@@ -72,33 +69,33 @@ pub fn next_position(
         let angle = angle_between_positions(&center, &new_position) * (PI / 180.0);
 
         Position {
-            x: (radius * angle.cos()) as i64,
-            y: (radius * angle.sin()) as i64,
+            x: radius * angle.cos(),
+            y: radius * angle.sin(),
         }
     }
 }
 
-pub const fn collision_with_edge(center: &Position, size: u64, width: u64, height: u64) -> bool {
-    let x_edge_positive = (width / 2) as i64;
-    let x_position_positive = center.x + size as i64;
+pub fn collision_with_edge(center: &Position, size: f32, width: f32, height: f32) -> bool {
+    let x_edge_positive = width / 2.0;
+    let x_position_positive = center.x + size;
     if x_position_positive >= x_edge_positive {
         return true;
     }
 
-    let x_edge_negative = width as i64 / -2;
-    let x_position_negative = center.x - size as i64;
+    let x_edge_negative = width / -2.0;
+    let x_position_negative = center.x - size;
     if x_position_negative <= x_edge_negative {
         return true;
     }
 
-    let y_edge_positive = (height / 2) as i64;
-    let y_position_positive = center.y + size as i64;
+    let y_edge_positive = height / 2.0;
+    let y_position_positive = center.y + size;
     if y_position_positive >= y_edge_positive {
         return true;
     }
 
-    let y_edge_negative = height as i64 / -2;
-    let y_position_negative = center.y - size as i64;
+    let y_edge_negative = height / -2.0;
+    let y_position_negative = center.y - size;
     if y_position_negative <= y_edge_negative {
         return true;
     }
@@ -106,28 +103,30 @@ pub const fn collision_with_edge(center: &Position, size: u64, width: u64, heigh
     false
 }
 
-pub fn random_position(width: u64, _height: u64) -> Position {
+pub fn random_position(width: f32, _height: f32) -> Position {
     let rng = &mut rand::thread_rng();
 
-    let radius = (width / 2) as i64;
+    let radius = (width / 2.0) as u32;
     let random_radius = (rng.gen_range(0..radius.pow(2)) as f32).sqrt();
     let angle = rng.gen_range(0.0..(2.0 * PI));
 
     Position {
-        x: (random_radius * angle.cos()) as i64,
-        y: (random_radius * angle.sin()) as i64,
+        x: random_radius * angle.cos(),
+        y: random_radius * angle.sin(),
     }
 }
 
 pub fn angle_between_positions(center: &Position, target: &Position) -> f32 {
-    let x_diff = (target.x - center.x) as f32;
-    let y_diff = (target.y - center.y) as f32;
+    let x_diff = target.x - center.x;
+    let y_diff = target.y - center.y;
     let angle = y_diff.atan2(x_diff) * (180.0 / PI);
     (angle + 360.0) % 360.0
 }
 
 pub fn distance_between_positions(position_1: &Position, position_2: &Position) -> f32 {
-    let distance_squared =
-        (position_1.x - position_2.x).pow(2) + (position_1.y - position_2.y).pow(2);
-    (distance_squared as f32).sqrt()
+    let distance_squared = (position_1.x - position_2.x).mul_add(
+        position_1.x - position_2.x,
+        (position_1.y - position_2.y).powi(2),
+    );
+    distance_squared.sqrt()
 }

--- a/native/game_backend/src/projectile.rs
+++ b/native/game_backend/src/projectile.rs
@@ -7,11 +7,11 @@ use crate::{effect::Effect, map::Position};
 pub struct ProjectileConfigFile {
     name: String,
     base_damage: u64,
-    base_speed: u64,
-    base_size: u64,
+    base_speed: f32,
+    base_size: f32,
     on_hit_effects: Vec<String>,
     duration_ms: u64,
-    max_distance: u64,
+    max_distance: f32,
     remove_on_collision: bool,
 }
 
@@ -19,11 +19,11 @@ pub struct ProjectileConfigFile {
 pub struct ProjectileConfig {
     pub name: String,
     base_damage: u64,
-    base_speed: u64,
-    base_size: u64,
+    base_speed: f32,
+    base_size: f32,
     on_hit_effects: Vec<Effect>,
     duration_ms: u64,
-    max_distance: u64,
+    max_distance: f32,
     remove_on_collision: bool,
 }
 
@@ -31,11 +31,11 @@ pub struct ProjectileConfig {
 pub struct Projectile {
     pub name: String,
     pub damage: u64,
-    pub speed: u64,
-    pub size: u64,
+    pub speed: f32,
+    pub size: f32,
     pub on_hit_effects: Vec<Effect>,
     pub duration_ms: u64,
-    pub max_distance: u64,
+    pub max_distance: f32,
     pub id: u64,
     pub position: Position,
     pub direction_angle: f32,

--- a/native/game_backend/src/skill.rs
+++ b/native/game_backend/src/skill.rs
@@ -28,7 +28,7 @@ pub enum SkillMechanicConfigFile {
     },
     Hit {
         damage: u64,
-        range: u64,
+        range: f32,
         cone_angle: u64,
         on_hit_effects: Vec<String>,
     },
@@ -42,7 +42,7 @@ pub enum SkillMechanicConfigFile {
     },
     MoveToTarget {
         duration_ms: u64,
-        max_range: u64,
+        max_range: f32,
     },
 }
 
@@ -53,7 +53,7 @@ pub enum SkillMechanic {
     },
     Hit {
         damage: u64,
-        range: u64,
+        range: f32,
         cone_angle: u64,
         on_hit_effects: Vec<Effect>,
     },
@@ -67,7 +67,7 @@ pub enum SkillMechanic {
     },
     MoveToTarget {
         duration_ms: u64,
-        max_range: u64,
+        max_range: f32,
     },
 }
 

--- a/priv/config.json
+++ b/priv/config.json
@@ -139,7 +139,7 @@
   "loots": [
     {
       "name": "loot_health",
-      "size": 50,
+      "size": 50.0,
       "pickup_mechanic": "CollisionUse",
       "effects": [
         "heal_30"
@@ -150,24 +150,24 @@
     {
       "name": "projectile_slingshot",
       "base_damage": 7,
-      "base_speed": 60,
-      "base_size": 20,
+      "base_speed": 60.0,
+      "base_size": 20.0,
       "remove_on_collision": true,
       "on_hit_effects": [],
       "duration_ms": 999999,
-      "max_distance": 1500
+      "max_distance": 1500.0
     },
     {
       "name": "projectile_poison_dart",
       "base_damage": 0,
-      "base_speed": 60,
-      "base_size": 10,
+      "base_speed": 60.0,
+      "base_size": 10.0,
       "remove_on_collision": false,
       "on_hit_effects": [
         "poison"
       ],
       "duration_ms": 999999,
-      "max_distance": 500
+      "max_distance": 500.0
     }
   ],
   "skills": [
@@ -208,7 +208,7 @@
         {
           "Hit": {
             "damage": 0,
-            "range": 975,
+            "range": 975.0,
             "cone_angle": 120,
             "on_hit_effects": ["muflus_hit_delay"]
           }
@@ -224,7 +224,7 @@
         {
           "Hit": {
             "damage": 20,
-            "range": 500,
+            "range": 500.0,
             "cone_angle": 360,
             "on_hit_effects": []
           }
@@ -262,8 +262,8 @@
     {
       "name": "h4ck",
       "active": true,
-      "base_speed": 20,
-      "base_size": 80,
+      "base_speed": 20.0,
+      "base_size": 80.0,
       "base_health": 100,
       "max_inventory_size": 1,
       "skills": {
@@ -276,8 +276,8 @@
     {
       "name": "muflus",
       "active": true,
-      "base_speed": 25,
-      "base_size": 150,
+      "base_speed": 25.0,
+      "base_size": 150.0,
       "base_health": 100,
       "max_inventory_size": 1,
       "skills": {
@@ -287,9 +287,9 @@
     }
   ],
   "game": {
-    "width": 10000,
-    "height": 10000,
-    "zone_starting_radius": 14000,
+    "width": 10000.0,
+    "height": 10000.0,
+    "zone_starting_radius": 14000.0,
     "zone_modifications": [
       {
         "duration_ms": 180000,
@@ -298,8 +298,8 @@
           "value": 0
         },
         "interval_ms": 500,
-        "min_radius": 5000,
-        "max_radius": 10000,
+        "min_radius": 5000.0,
+        "max_radius": 10000.0,
         "outside_radius_effects": []
       },
       {
@@ -309,8 +309,8 @@
           "value": -45
         },
         "interval_ms": 100,
-        "min_radius": 5000,
-        "max_radius": 10000,
+        "min_radius": 5000.0,
+        "max_radius": 10000.0,
         "outside_radius_effects": [
           "damage_outside_area"
         ]
@@ -322,8 +322,8 @@
           "value": -25
         },
         "interval_ms": 100,
-        "min_radius": 2500,
-        "max_radius": 10000,
+        "min_radius": 2500.0,
+        "max_radius": 10000.0,
         "outside_radius_effects": [
           "damage_outside_area"
         ]
@@ -335,8 +335,8 @@
           "value": -15
         },
         "interval_ms": 100,
-        "min_radius": 1000,
-        "max_radius": 10000,
+        "min_radius": 1000.0,
+        "max_radius": 10000.0,
         "outside_radius_effects": [
           "damage_outside_area"
         ]
@@ -349,54 +349,54 @@
         },
         "interval_ms": 100,
         "min_radius": 0,
-        "max_radius": 10000,
+        "max_radius": 10000.0,
         "outside_radius_effects": [
           "damage_outside_area"
         ]
       }
     ],
     "loot_interval_ms": 7000,
-    "auto_aim_max_distance": 2000,
+    "auto_aim_max_distance": 2000.0,
     "initial_positions": [
       {
-        "x": -1500,
-        "y": 4000
+        "x": -1500.0,
+        "y": 4000.0
       },
       {
-        "x": -3500,
-        "y": 2000
+        "x": -3500.0,
+        "y": 2000.0
       },
       {
-        "x": 0,
-        "y": 2000
+        "x": 0.0,
+        "y": 2000.0
       },
       {
-        "x": 1500,
-        "y": 4000
+        "x": 1500.0,
+        "y": 4000.0
       },
       {
-        "x": 3500,
-        "y": 2000
+        "x": 3500.0,
+        "y": 2000.0
       },
       {
-        "x": 3500,
-        "y": -2000
+        "x": 3500.0,
+        "y": -2000.0
       },
       {
-        "x": 1500,
-        "y": -4000
+        "x": 1500.0,
+        "y": -4000.0
       },
       {
-        "x": 0,
-        "y": -2000
+        "x": 0.0,
+        "y": -2000.0
       },
       {
-        "x": -1500,
-        "y": -4000
+        "x": -1500.0,
+        "y": -4000.0
       },
       {
-        "x": -3500,
-        "y": -2000
+        "x": -3500.0,
+        "y": -2000.0
       }
     ]
   }

--- a/priv/repo/migrations/20231221144825_change_position_integers_to_floats.exs
+++ b/priv/repo/migrations/20231221144825_change_position_integers_to_floats.exs
@@ -1,0 +1,31 @@
+defmodule DarkWorldsServer.Repo.Migrations.ChangePositionIntegersToFloats do
+  use Ecto.Migration
+
+  def change do
+    alter table(:characters) do
+      modify :base_speed, :float, from: :integer
+      modify :base_size, :float, from: :integer
+    end
+
+    alter table(:projectiles) do
+      modify :base_speed, :float, from: :integer
+      modify :base_size, :float, from: :integer
+      modify :max_distance, :float, from: :integer
+    end
+
+    alter table(:loots) do
+      modify :size, :float, from: :integer
+    end
+
+    alter table(:games) do
+      modify :width, :float, from: :integer
+      modify :height, :float, from: :integer
+      modify :zone_starting_radius, :float, from: :integer
+    end
+
+    alter table(:zone_modifications) do
+      modify :min_radius, :float, from: :integer
+      modify :max_radius, :float, from: :integer
+    end
+  end
+end

--- a/priv/test_config.json
+++ b/priv/test_config.json
@@ -119,13 +119,13 @@
   "loots": [
     {
       "name": "loot_health",
-      "size": 50,
+      "size": 50.0,
       "pickup_mechanic": "CollisionUse",
       "effects": ["heal_30"]
     },
     {
       "name": "loot_health_inventory",
-      "size": 50,
+      "size": 50.0,
       "pickup_mechanic": "CollisionToInventory",
       "effects": ["heal_30"]
     }
@@ -134,22 +134,22 @@
     {
       "name": "projectile_slingshot",
       "base_damage": 8,
-      "base_speed": 40,
-      "base_size": 20,
+      "base_speed": 40.0,
+      "base_size": 20.0,
       "remove_on_collision": true,
       "on_hit_effects": [],
       "duration_ms": 999999,
-      "max_distance": 999999
+      "max_distance": 999999.0
     },
     {
       "name": "projectile_poison_dart",
       "base_damage": 0,
-      "base_speed": 60,
-      "base_size": 10,
+      "base_speed": 60.0,
+      "base_size": 10.0,
       "remove_on_collision": false,
       "on_hit_effects": ["poison"],
       "duration_ms": 999999,
-      "max_distance": 500
+      "max_distance": 500.0
     }
   ],
   "skills": [
@@ -190,7 +190,7 @@
         {
           "Hit": {
             "damage": 14,
-            "range": 1000,
+            "range": 1000.0,
             "cone_angle": 120,
             "on_hit_effects": []
           }
@@ -206,7 +206,7 @@
         {
           "Hit": {
             "damage": 20,
-            "range": 500,
+            "range": 500.0,
             "cone_angle": 360,
             "on_hit_effects": []
           }
@@ -244,8 +244,8 @@
     {
       "name": "h4ck",
       "active": true,
-      "base_speed": 20,
-      "base_size": 80,
+      "base_speed": 20.0,
+      "base_size": 80.0,
       "base_health": 100,
       "max_inventory_size": 1,
       "skills": {
@@ -257,8 +257,8 @@
     {
       "name": "muflus",
       "active": true,
-      "base_speed": 20,
-      "base_size": 100,
+      "base_speed": 20.0,
+      "base_size": 100.0,
       "base_health": 100,
       "max_inventory_size": 1,
       "skills": {
@@ -268,9 +268,9 @@
     }
   ],
   "game": {
-    "width": 10000,
-    "height": 10000,
-    "zone_starting_radius": 14000,
+    "width": 10000.0,
+    "height": 10000.0,
+    "zone_starting_radius": 14000.0,
     "zone_modifications": [
       {
         "duration_ms": 30000,
@@ -279,8 +279,8 @@
           "value": 0
         },
         "interval_ms": 500,
-        "min_radius": 6000,
-        "max_radius": 10000,
+        "min_radius": 6000.0,
+        "max_radius": 10000.0,
         "outside_radius_effects": ["damage_outside_area"]
       },
       {
@@ -290,8 +290,8 @@
           "value": -45
         },
         "interval_ms": 100,
-        "min_radius": 3000,
-        "max_radius": 10000,
+        "min_radius": 3000.0,
+        "max_radius": 10000.0,
         "outside_radius_effects": ["damage_outside_area"]
       },
       {
@@ -301,27 +301,27 @@
           "value": -45
         },
         "interval_ms": 100,
-        "min_radius": 100,
-        "max_radius": 10000,
+        "min_radius": 100.0,
+        "max_radius": 10000.0,
         "outside_radius_effects": [
           "damage_outside_area"
         ]
       }
     ],
     "loot_interval_ms": 7000,
-    "auto_aim_max_distance": 1000,
+    "auto_aim_max_distance": 1000.0,
     "initial_positions": [
       {
-        "x": -4500,
-        "y": 1500
+        "x": -4500.0,
+        "y": 1500.0
       },
       {
-        "x": 3000,
-        "y": 4000
+        "x": 3000.0,
+        "y": 4000.0
       },
       {
-        "x": -4500,
-        "y": -1500
+        "x": -4500.0,
+        "y": -1500.0
       }
     ]
   }


### PR DESCRIPTION
This is a reboot of #60 because the merge conflicts got too complicated to fix and to reduce the scope a bit

This PR modify the different integer types use to represent position related things to a float (`f32` in Rust)

The non-exhaustive list of modified thing:
- size
- speed
- position X and Y coordinates
- radius
- max_distance
- minimum and maximum radius of map

You can test with https://github.com/lambdaclass/curse_of_mirra/pull/1292