### PR TITLE
Delayed random multishot (H4ck ulti)

### DIFF
--- a/docs/src/configuration/skills.md
+++ b/docs/src/configuration/skills.md
@@ -25,6 +25,9 @@ These are the mechanics so far. Every mechanic will add a configuration field wi
   * `projectile`: Projectile to shoot
   * `count`: How many projectiles will be shot
   * `cone_angle`: Defines how wide is the angle to spread the projectiles on, see [Explaining cone_angle](#explaining-cone_angle)
+  * `distribution`: Defines how the projectiles are distributed in the `cone_angle`
+    - `Evenly`: Projectiles are distributed evenly
+    - `Randomly`: Projectiles are distributed randomly
 - `MoveToTarget`: Player will be moved to target position
   * `duration_ms`: How long it takes to move the player, 0 means instantly
   * `max_range`: Maximum distance allowed to move, if target is beyond this limit movement will be capped to this point

--- a/native/game_backend/src/game.rs
+++ b/native/game_backend/src/game.rs
@@ -305,6 +305,7 @@ impl GameState {
                             projectile: projectile_config,
                             count,
                             cone_angle,
+                            distribution: _,
                         } => {
                             let direction_distribution =
                                 distribute_angle(direction_angle, cone_angle, count);

--- a/native/game_backend/src/skill.rs
+++ b/native/game_backend/src/skill.rs
@@ -39,6 +39,7 @@ pub enum SkillMechanicConfigFile {
         projectile: String,
         count: u64,
         cone_angle: u64,
+        distribution: MultiShootDistribution,
     },
     MoveToTarget {
         duration_ms: u64,
@@ -64,11 +65,18 @@ pub enum SkillMechanic {
         projectile: ProjectileConfig,
         count: u64,
         cone_angle: u64,
+        distribution: MultiShootDistribution,
     },
     MoveToTarget {
         duration_ms: u64,
         max_range: u64,
     },
+}
+
+#[derive(Deserialize, NifTaggedEnum, Clone)]
+pub enum MultiShootDistribution {
+    Evenly,
+    Randomly,
 }
 
 impl SkillConfig {
@@ -152,6 +160,7 @@ impl SkillMechanic {
                     projectile,
                     count,
                     cone_angle,
+                    distribution,
                 } => {
                     let projectile = projectiles
                         .iter()
@@ -167,6 +176,7 @@ impl SkillMechanic {
                         projectile: projectile.clone(),
                         count,
                         cone_angle,
+                        distribution,
                     }
                 }
                 SkillMechanicConfigFile::MoveToTarget {

--- a/priv/config.json
+++ b/priv/config.json
@@ -181,7 +181,8 @@
           "MultiShoot": {
             "projectile": "projectile_slingshot",
             "count": 3,
-            "cone_angle": 40
+            "cone_angle": 40,
+            "distribution": "Evenly"
           }
         }
       ]

--- a/priv/config.json
+++ b/priv/config.json
@@ -107,8 +107,8 @@
       "effect_time_type": {
         "Periodic": {
           "instant_applicaiton": true,
-          "interval_ms": 130,
-          "trigger_count": 10
+          "interval_ms": 100,
+          "trigger_count": 18
         }
       },
       "player_attributes": [],
@@ -246,14 +246,17 @@
       ]
     },
     {
-      "name": "single_slingshot",
+      "name": "random_shot",
       "cooldown_ms": 800,
       "execution_duration_ms": 250,
       "is_passive": false,
       "mechanics": [
         {
-          "SimpleShoot": {
-            "projectile": "projectile_slingshot"
+          "MultiShoot": {
+            "projectile": "projectile_slingshot",
+            "count": 1,
+            "cone_angle": 90,
+            "distribution": "Randomly"
           }
         }
       ]
@@ -271,7 +274,7 @@
         "1": "slingshot",
         "2": "denial_of_service",
         "3": "poison_dart",
-        "4": "single_slingshot"
+        "4": "random_shot"
       }
     },
     {

--- a/priv/test_config.json
+++ b/priv/test_config.json
@@ -163,7 +163,8 @@
           "MultiShoot": {
             "projectile": "projectile_slingshot",
             "count": 3,
-            "cone_angle": 40
+            "cone_angle": 40,
+            "distribution": "Evenly"
           }
         }
       ]


### PR DESCRIPTION
This PR adds `distribution` attribute to the `MultiShoot` skill mechanic so we can decide how the shots are going to be distributed in the available angle

~Sadly I haven't been able to test this PR in the client because H4ck and projectiles seem to be broken, but we can still review and merge this and eventually test~

To test you will need to modify the skills for Muflus in `config.json` as follows:
```
"skills": {
  "1": "denial_of_service",
  "2": "circle_hit",
  "4": "random_shot"
}
```

And in Unity you will need to modify Muflus scriptable object (`Assets/ScriptableObjects/Characters/Muflus.asset`) and in the `Skills Info` section modify the first element to `H4ck_Basic` (path `Assets/ScriptableObjects/Skills/H4ck/H4ck_Basic.asset`)