### PR TITLE
check blocker actions in next_action list instead of current actions

### DIFF
--- a/native/game_backend/src/player.rs
+++ b/native/game_backend/src/player.rs
@@ -338,7 +338,7 @@ impl Player {
 
     pub fn can_do_action(&self) -> bool {
         !self
-            .action
+            .next_actions
             .iter()
             .any(|action_tracker| action_tracker.action != Action::Moving)
     }


### PR DESCRIPTION
This pr aims to fix an error in the game where for example:
- You are walking left and try to hit to the right muflus ends up throwing a hit to the left