### PR TITLE
Restore lobby timeout timer

### DIFF
--- a/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
+++ b/lib/dark_worlds_server/matchmaking/matching_coordinator.ex
@@ -6,7 +6,7 @@ defmodule DarkWorldsServer.Matchmaking.MatchingCoordinator do
   ## Amount of players needed to start a game
   @session_player_amount 10
   ## Time to wait for a matching session to be full
-  @start_game_timeout_ms 3_000
+  @start_game_timeout_ms 9_500
 
   #######
   # API #


### PR DESCRIPTION
The lobby timeout time was changed unintentionally and we'll restore it 