### PR TITLE
Run config db setup on start & update readme

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,1 +1,1 @@
-if is_nil(DarkWorldsServer.Config.Games.get_game()), do: DarkWorldsServer.Utils.Config.clean_import()
+DarkWorldsServer.Utils.Config.clean_import()

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,1 @@
+if is_nil(DarkWorldsServer.Config.Games.get_game()), do: DarkWorldsServer.Utils.Config.clean_import()

--- a/README.md
+++ b/README.md
@@ -73,4 +73,6 @@ Then once you are inside the Elixir terminal, run:
 DarkWorldsServer.Utils.Config.clean_import()
 ```
 
+You need to run this command so that changes to the `config.json` get reflected.
+
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@ Open source backend developed by LambdaClass in Elixir, for the communication, a
 
 ## Table of Contents
 
-- [Documentation](#documentation)
-- [Installation](#installation)
-- [Running the Backend](#running-the-backend)
-- [Contributing](#contributing)
+- [Lambda Game Backend](#lambda-game-backend)
+  - [Table of Contents](#table-of-contents)
+  - [Documentation](#documentation)
+  - [Installation](#installation)
+  - [Running the Backend](#running-the-backend)
+    - [Requirements](#requirements)
+  - [Contributing](#contributing)
 
 
 ## Documentation
@@ -62,6 +65,12 @@ git clone https://github.com/lambdaclass/game_backend
 make db
 make setup
 make start
+```
+
+Then once you are inside the Elixir terminal, run:
+
+```elixir
+DarkWorldsServer.Utils.Config.clean_import()
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -67,12 +67,10 @@ make setup
 make start
 ```
 
-Then once you are inside the Elixir terminal, run:
+Whenever you make changes to the game's `config.json`, you will need to run this so that they get reflected:
 
 ```elixir
 DarkWorldsServer.Utils.Config.clean_import()
 ```
-
-You need to run this command so that changes to the `config.json` get reflected.
 
 ## Contributing


### PR DESCRIPTION
After #104 you will get errors if you try to run a game without setting up the DB beforehand. This PR creates a .iex.exs file that gets triggered on iex start, which executes the config import. This will take care of config issues for devs.

Note that this does not automate changes to the config though, you will need to restart the app for the command to execute or run it manually.