### PR TITLE
Fix cone angle calculation

### DIFF
--- a/native/game_backend/src/map.rs
+++ b/native/game_backend/src/map.rs
@@ -43,7 +43,7 @@ pub fn in_cone_angle_range(
     let relative_angle = angle - center_player.direction;
     let normalized_angle = (relative_angle + 360.0) % 360.0;
 
-    normalized_angle < (cone_angle / 2.0)
+    360.0 - (cone_angle / 2.0) < normalized_angle || normalized_angle < (cone_angle / 2.0)
 }
 
 pub fn next_position(

--- a/priv/config.json
+++ b/priv/config.json
@@ -209,7 +209,7 @@
           "Hit": {
             "damage": 0,
             "range": 975,
-            "cone_angle": 120,
+            "cone_angle": 90,
             "on_hit_effects": ["muflus_hit_delay"]
           }
         }


### PR DESCRIPTION
Nowdays we have an incomplete angle calculation when we check if a hit actually hitted an enemy, this is because we're only testing if the up half of the angle hitted and we should check the other side. I'll explain myself in the following diagrams

### disclaimer: the angles represented in these diagram is relative, it'll be always the same since it's the angle from the player to the target, so for example is the target is on top of the player the "270" would be a 0 instead

Before this pr the only side considered as hit were the players inside of the "up hit half" and after this pr we will consider both sides hit
![player hit range](https://github.com/lambdaclass/game_backend/assets/106101218/8bc2f8bc-077d-4b4c-8626-e35d6f99b450)

The error that this calculation caused was something like this:

![no hit case](https://github.com/lambdaclass/game_backend/assets/106101218/5e2c1e4b-c56f-4c1e-ba4a-909355ed6b06)

The target is clearly inside of the cone but since we're not checking the angles from the down half we are missing the hit

This pr will also reduce the muflus's hit angle a little bit so it feels more realistic
