### PR TITLE
Add delay in bot activation while preparing for battle

### DIFF
--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -86,7 +86,7 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
 
   @impl GenServer
   def handle_cast({:add_bot, bot_id}, state) do
-    #FIXME remove this once we implement the server blocking the messages while the match loads
+    #TODO remove this once we implement the server blocking the messages while the match loads
     Process.send_after(self(), {:decide_action, bot_id}, @prepare_for_battle_time_ms)
     Process.send_after(self(), {:do_action, bot_id}, @prepare_for_battle_time_ms)
 

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -50,6 +50,8 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
   # keep in mind that the chace timer is also determined by the random factor value
   @chase_timer_adittive 5
 
+  @prepare_for_battle_time_ms 10_000
+
   #######
   # API #
   #######
@@ -84,8 +86,9 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
 
   @impl GenServer
   def handle_cast({:add_bot, bot_id}, state) do
-    send(self(), {:decide_action, bot_id})
-    send(self(), {:do_action, bot_id})
+    #FIXME remove this once we implement the server blocking the messages while the match loads
+    Process.send_after(self(), {:decide_action, bot_id}, @prepare_for_battle_time_ms)
+    Process.send_after(self(), {:do_action, bot_id}, @prepare_for_battle_time_ms)
 
     {:noreply,
      put_in(state, [:bots, bot_id], %{

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -86,7 +86,11 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
 
   @impl GenServer
   def handle_cast({:add_bot, bot_id}, state) do
+<<<<<<< Updated upstream
     #TODO remove this once we implement the server blocking the messages while the match loads
+=======
+    # FIXME remove this once we implement the server blocking the messages while the match loads
+>>>>>>> Stashed changes
     Process.send_after(self(), {:decide_action, bot_id}, @prepare_for_battle_time_ms)
     Process.send_after(self(), {:do_action, bot_id}, @prepare_for_battle_time_ms)
 

--- a/lib/dark_worlds_server/bot/bot_player.ex
+++ b/lib/dark_worlds_server/bot/bot_player.ex
@@ -86,11 +86,7 @@ defmodule DarkWorldsServer.RunnerSupervisor.BotPlayer do
 
   @impl GenServer
   def handle_cast({:add_bot, bot_id}, state) do
-<<<<<<< Updated upstream
-    #TODO remove this once we implement the server blocking the messages while the match loads
-=======
-    # FIXME remove this once we implement the server blocking the messages while the match loads
->>>>>>> Stashed changes
+    # TODO remove this once we implement the server blocking the messages while the match loads
     Process.send_after(self(), {:decide_action, bot_id}, @prepare_for_battle_time_ms)
     Process.send_after(self(), {:do_action, bot_id}, @prepare_for_battle_time_ms)
 


### PR DESCRIPTION
The bots were able to move before the preparing for battle ends, this pr will add a delay in the bot activation in some kind of patch until we implement a proper wait in the server response so nobody can move while the battle is being prepared