### PR TITLE
Check collisions in player move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ generate-js-protos:
 
 generate-protos: generate-ex-protos generate-js-protos
 
-check: 
-	mix format --check-formatted
+check: format
 	mix credo --strict
 	mix test
+
+format:
+	mix format --check-formatted
+	cd native/state_manager_backend && cargo fmt --all

--- a/lib/state_manager_backend.ex
+++ b/lib/state_manager_backend.ex
@@ -8,9 +8,8 @@ defmodule StateManagerBackend do
 
   # When loading a NIF module, dummy clauses for all NIF function are required.
   # NIF dummies usually just error out when called when the NIF is not loaded, as that should never normally happen.
-  def new_game(), do: :erlang.nif_error(:nif_not_loaded)
+  def new_game, do: :erlang.nif_error(:nif_not_loaded)
   def add(_arg1, _arg2), do: :erlang.nif_error(:nif_not_loaded)
   def add_player(_game_state, _player_id), do: :erlang.nif_error(:nif_not_loaded)
-  def move_player(_game_state, _player_id, _x, _y), do: :erlang.nif_error(:nif_not_loaded)
-  def check_collisions(_game_state, _player_id, _radius), do: :erlang.nif_error(:nif_not_loaded)
+  def move_player(_game_state, _player_id, _direc_x, _direc_y), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/state_manager_backend/src/game_state.rs
+++ b/native/state_manager_backend/src/game_state.rs
@@ -1,5 +1,5 @@
+use crate::{calculate_distance, player::Player};
 use rustler::NifMap;
-use crate::player::Player;
 use std::collections::HashMap;
 
 #[derive(NifMap)]
@@ -9,8 +9,40 @@ pub struct GameState {
 
 impl GameState {
     pub fn new() -> GameState {
-        GameState{
+        GameState {
             players: HashMap::new(),
         }
     }
+
+    /// Move the player in the directions x and y
+    /// Checking collisions with the other Players in the game
+    pub fn move_player(&mut self, player_id: u64, direc_x: f64, direc_y: f64) {
+        if !is_valid_move(self, &player_id, direc_x, direc_y) {
+            return;
+        }
+        let player = self.players.get_mut(&player_id).unwrap();
+        player.position.x += direc_x * player.speed;
+        player.position.y += direc_y * player.speed;
+    }
+}
+
+/// Check collisions with other Players in the game
+pub fn is_valid_move(game_state: &GameState, player_id: &u64, direc_x: f64, direc_y: f64) -> bool {
+    let mut player = game_state.players.get(player_id).unwrap().clone();
+    player.position.x += direc_x * player.speed;
+    player.position.y += direc_y * player.speed;
+
+    let new_position = player.position;
+
+    for (id, other_player) in &game_state.players {
+        if id == &player.id {
+            continue;
+        }
+
+        let distance = calculate_distance(&new_position, &other_player.position);
+        if distance < player.size / 2.0 + other_player.size / 2.0 {
+            return false;
+        }
+    }
+    true
 }

--- a/native/state_manager_backend/src/lib.rs
+++ b/native/state_manager_backend/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)] // rustler macros generate non snake case names and dont use this allow themselves
 
-mod player;
 mod game_state;
+mod player;
 
 use crate::game_state::GameState;
 use crate::player::{Player, Position};
@@ -27,30 +27,10 @@ fn add_player(game_state: GameState, player_id: u64) -> GameState {
 }
 
 #[rustler::nif()]
-fn move_player(game_state: GameState, player_id: u64, x: f64, y: f64) -> GameState {
+fn move_player(game_state: GameState, player_id: u64, direc_x: f64, direc_y: f64) -> GameState {
     let mut game_state: GameState = game_state;
-    let player = game_state.players.get_mut(&player_id).unwrap();
-    player.move_player(x, y);
+    game_state.move_player(player_id, direc_x, direc_y);
     game_state
-}
-
-#[rustler::nif()]
-/// Check players inside the player_id radius
-/// Return a list of the players id inside the radius Vec<player_id>
-fn check_collisions(game_state: GameState, player_id: u64, radius: f64) -> Vec<u64> {
-    let game_state: GameState = game_state;
-    let player = game_state.players.get(&player_id).unwrap();
-    let mut result = Vec::new();
-    for (id, other_player) in &game_state.players {
-        if id == &player.id {
-            continue;
-        }
-        let d = calculate_distance(&player.position, &other_player.position);
-        if d <= radius {
-            result.push(*id)
-        }
-    }
-    result
 }
 
 /// Calculate distance between two positions
@@ -60,11 +40,7 @@ fn calculate_distance(a: &Position, b: &Position) -> f64 {
     (x.powi(2) + y.powi(2)).sqrt()
 }
 
-
-rustler::init!("Elixir.StateManagerBackend", [
-    add,
-    move_player,
-    new_game,
-    add_player,
-    check_collisions
-]);
+rustler::init!(
+    "Elixir.StateManagerBackend",
+    [add, move_player, new_game, add_player,]
+);

--- a/native/state_manager_backend/src/player.rs
+++ b/native/state_manager_backend/src/player.rs
@@ -6,27 +6,23 @@ pub struct Player {
     pub(crate) position: Position,
     pub(crate) size: f64,
     life: u64,
-    speed: f64,
+    pub(crate) speed: f64,
 }
 
-#[derive(NifMap, Clone)]
+#[derive(NifMap, Clone, Debug)]
 pub struct Position {
     pub(crate) x: f64,
     pub(crate) y: f64,
 }
 
 impl Player {
-    pub fn new(id: u64, initial_position: Position, size: f64, life: u64, speed: f64,) -> Player {
-        Player{
+    pub fn new(id: u64, initial_position: Position, size: f64, life: u64, speed: f64) -> Player {
+        Player {
             id,
             position: initial_position,
             size,
             life,
             speed,
         }
-    }
-    pub fn move_player(&mut self, x: f64, y: f64) {
-        self.position.x += x * self.speed;
-        self.position.y += y * self.speed;
     }
 }


### PR DESCRIPTION
# Check collisions in player move

* Update the logic of the `StateManagerBackend::move_player`:
  * Now it executes the `GameState::move_player `method, which checks collisions with the `fn is_valid_move`
* Delete the unused functions: `Player::move_player `method  and `StateManagerBackend::check_collisions`
* Add` make format `command, to format the rust files